### PR TITLE
Use our Alpine-friendly version of diskspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bunyan": "^1.5.1",
     "cheerio": "^0.17.0",
     "commander": "^2.3.0",
-    "diskspace": "git+http://github.com/Financial-Times/diskspace.js.git",
+    "diskspace": "git+http://github.com/Financial-Times/diskspace.js.git#alpine",
     "express": "^4.12.3",
     "express-ftwebservice": "^2.0.2",
     "glob": "^4.0.5",


### PR DESCRIPTION
I've had to push an Alpine-specific version of the diskspace module, because `df` on Alpine has different output. This caused the inodes check on the `__health` endpoint to fail. This highlights how fragile the diskspace module is, I've opened an issue to find a replacement: #22.

Here's the diff for the `alpine` branch of diskspace: https://github.com/Financial-Times/diskspace.js/compare/master...Financial-Times:alpine