### PR TITLE
Allow metrics to be recorded for QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Origami Build Service is configured using environment variables. In development,
   * `LOG_LEVEL`: Syslog-compatible level at which to emit log events to stdout (`trace`, `debug`, `info`, `warn`, `error`, or `crit`).
   * `GITHUB_USERNAME`: A GitHub username which has access to any private repositories that bower needs to see.
   * `GITHUB_PASSWORD`: The GitHub password corresponding to `GITHUB_USERNAME`.
+  * `METRICS_ENV`: Which environment to store metrics under. This defaults to `NODE_ENV`, which allows us to measure QA/production metrics separately.
 
 
 Testing

--- a/lib/monitoring/metrics.js
+++ b/lib/monitoring/metrics.js
@@ -8,7 +8,7 @@ const log = require('../utils/log');
 const reportInterval = 5000;
 const graphiteHost = process.env.GRAPHITE_HOST || null;
 const graphitePort = process.env.GRAPHITE_PORT || 2003;
-const envName = process.env.NODE_ENV || 'unknown';
+const envName = process.env.METRICS_ENV || process.env.NODE_ENV || 'unknown';
 const processIdentifier = process.env.DYNO ? 'dyno-' + process.env.DYNO.replace('.', '') : 'pid-' + process.pid;
 
 let timer = null;


### PR DESCRIPTION
This will ensure that QA doesn't report metrics as "production" which would skew our production statistics. Production will not specify a `METRICS_ENV` variable, and QA will have it set to "qa".