### PR TITLE
Cache the built Docker image on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,20 @@ build:
 
 build-dev:
 	@docker-compose build
+	@$(DONE)
 
 promote:
 	@docker pull $(DOCKER_REGISTRY_ENDPOINT_QA)
 	@docker tag $(DOCKER_REGISTRY_ENDPOINT_QA) $(DOCKER_REGISTRY_ENDPOINT_PROD)
 	@docker push $(DOCKER_REGISTRY_ENDPOINT_PROD)
+	@$(DONE)
+
+ci-docker-cache-load:
+	@if [ -e ~/docker/obs-qa.tar ]; then docker load -i ~/docker/obs-qa.tar; fi
+	@$(DONE)
+
+ci-docker-cache-save:
+	@mkdir -p ~/docker; docker save $(DOCKER_REGISTRY_ENDPOINT_QA) > ~/docker/obs-qa.tar
 	@$(DONE)
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,14 @@ machine:
     - docker
 
 dependencies:
+  cache_directories:
+    - ~/docker
   override:
     - make install
+    # Note: we have to repeat the deployment branch here. It's not great,
+    # but there's currently no way around it – to cache the docker image
+    # it has to be built during the "dependencies" step
+    - 'if [ "${CIRCLE_BRANCH}" == "master" ]; then make ci-docker-cache-load build ci-docker-cache-save; fi'
 
 test:
   override:


### PR DESCRIPTION
This drastically improves the speed of QA deployments with a primed cache.

Before: **~13 minutes**
After: **~6 minutes** (not 100% sure yet as haven't tested the push, seeing ~3 minutes with no push)