### PR TITLE
Implement automated change requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,15 @@ promote:
 	@docker pull $(DOCKER_REGISTRY_ENDPOINT_QA)
 	@docker tag $(DOCKER_REGISTRY_ENDPOINT_QA) $(DOCKER_REGISTRY_ENDPOINT_PROD)
 	@docker push $(DOCKER_REGISTRY_ENDPOINT_PROD)
+	@make change-request-prod
+	@$(DONE)
+
+change-request-qa:
+	@./tools/change-request.js --environment Test --gateway konstructor || true
+	@$(DONE)
+
+change-request-prod:
+	@./tools/change-request.js --environment Production --gateway internal || true
 	@$(DONE)
 
 ci-docker-cache-load:

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ The [production][heroku-production] and [QA][heroku-qa] applications run on [Her
 docker login --email=_ --username=_ --password=$(heroku auth:token) registry.heroku.com
 ```
 
-Now deploy the last QA image by running the following, avoiding having to build locally:
+You'll need to provide your GitHub username for change request logging, ensure you've been [added to this spreadsheet][developer-spreadsheet]. Now deploy the last QA image by running the following, avoiding having to build locally:
 
 ```sh
-make promote
+GITHUB_USERNAME=yourgithubusername make promote
 ```
 
 We use [Semantic Versioning][semver] to tag releases. Only tagged releases should hit production, this ensures that the `__about` endpoint is informative. To tag a new release, use one of the following (this is the only time we allow a commit directly to `master`):
@@ -260,6 +260,7 @@ The Financial Times has published this software under the [MIT license][license]
 
 [build-service]: https://build.origami.ft.com/
 [ci]: https://circleci.com/gh/Financial-Times/origami-build-service
+[developer-spreadsheet]: https://docs.google.com/spreadsheets/d/1mbJQYJOgXAH2KfgKUM1Vgxq8FUIrahumb39wzsgStu0/edit#gid=0
 [docker-compose]: https://docs.docker.com/compose/
 [docker-mac]: http://docs.docker.com/mac/step_one/
 [docker-machine]: https://docs.docker.com/machine/

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
   cache_directories:
     - ~/docker
   override:
-    - make install
+    - npm install
     # Note: we have to repeat the deployment branch here. It's not great,
     # but there's currently no way around it – to cache the docker image
     # it has to be built during the "dependencies" step
@@ -27,3 +27,4 @@ deployment:
       - 'echo "machine api.heroku.com login rowan.manning@ft.com password ${HEROKU_AUTH_TOKEN}" >> ${HOME}/.netrc; chmod 0600 /home/ubuntu/.netrc;'
       - 'docker login --email=_ --username=_ --password=$(heroku auth:token) registry.heroku.com'
       - 'make deploy'
+      - 'make change-request-qa'

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chai": "^3.5.0",
     "eslint": "^2.2.0",
     "istanbul": "^0.4.2",
+    "konstructor-api-client": "1.0.0-alpha.3",
     "lintspaces-cli": "^0.1.1",
     "mocha": "^2.4.5",
     "mockery": "^1.4.0",

--- a/tools/change-request.js
+++ b/tools/change-request.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+
+const KonstructorApiClient = require('konstructor-api-client');
+const pkg = require('../package.json');
+const program = require('commander');
+
+// Command-line configuration
+program
+	.usage('[options]')
+	.option(
+		'-g, --gateway <gateway>',
+		'a gateway to log the change request to, one of "internal", "konstructor", "mashery", "test". Default: "test"',
+		'test'
+	)
+	.option(
+		'-a, --api-key <key>',
+		'an API key for use with "konstructor" or "mashery" gateways',
+		process.env.KONSTRUCTOR_API_KEY
+	)
+	.option(
+		'-e, --environment <environment>',
+		'the environment the change request applies to. One of "Production", "Test", "Development", "Disaster Recovery". Default: "Test"'
+	)
+	.parse(process.argv);
+
+// Build change request
+const type = 'releaselog';
+const username = process.env.CIRCLE_USERNAME || process.env.GITHUB_USERNAME;
+const summary = `Releasing Origami Build Service version ${pkg.version} to ${program.environment}`;
+const description = `Release triggered by ${username}`;
+const serviceId = 'origami-buildservice ServiceModule';
+const notifyChannel = '#origami-internal';
+
+// We need a username
+if (!username) {
+	console.error('Please provide a GitHub username in the `GITHUB_USERNAME` environment variable');
+	process.exit(1);
+}
+
+// Gather up the data
+const openData = {
+	summaryOfChange: summary,
+	changeDescription: description,
+	environment: program.environment,
+	serviceIds: serviceId,
+	notifyChannel: notifyChannel
+};
+const closeData = {
+	notifyChannel: notifyChannel
+};
+
+// Create a change request
+console.log('Creating a change request');
+const apiClient = new KonstructorApiClient(program.gateway, program.apiKey);
+KonstructorApiClient.getEmailFromUsername(username)
+	.then(email => {
+		openData.ownerEmailAddress = openData.resourceOne = closeData.closedByEmailAddress = email;
+		return apiClient.createAndCloseChangeRequest(type, openData, closeData);
+	})
+	.then(changeRequest => {
+		console.log('Created and closed change request %s', changeRequest.id);
+	})
+	.catch(error => {
+		if (error.responseBody) {
+			console.error(error.message);
+			console.error(error.responseBody.message);
+		} else {
+			console.error(error.stack || error.message);
+		}
+		process.exit(1);
+	});


### PR DESCRIPTION
This adds two new Make tasks:

```sh
make change-request-qa
make change-request-prod
```

Both of these use `tools/change-request.js`, which sets some defaults for the created change request. I based these defaults on what the Next team have been sending.

This tool uses the Node.js module [`konstructor-api-client`](https://github.com/Financial-Times/konstructor-api-client-node). We depend on an Alpha version while we're testing, we'll switch to a semver range once we release `1.0.0`.

## QA Deploy

Because CI is outside of our network we need a Konstructor API key, which is set using an environment variable on CircleCI.

The tool needs a GitHub username; in CI we can get this from the `CIRCLE_USERNAME` environment variable. We use this to find an associated `ft.com` email address via [this spreadsheet](https://docs.google.com/spreadsheets/d/1mbJQYJOgXAH2KfgKUM1Vgxq8FUIrahumb39wzsgStu0/edit#gid=0). Konstructor then uses the email address to set the appropriate change request owner in Salesforce.

## Production Deploy

When deploying to production through Make, we now also attempt to open a change request. Because we have no `CIRCLE_USERNAME` environment variable locally, we have to set our GitHub username. The documentation outlines this:

```sh
make promote
```

becomes:

```sh
GITHUB_USERNAME=yourgithubusername make promote
```

## Failure

If the change request fails, we don't fail the build or prevent a deploy. This is because the next team have observed some random failures in the API, and cancelling a deploy because of these is disruptive.

It's up to the person who's deploying to decide if it's important enough to try again, or manually log a change request through Salesforce. It's likely that we won't bother for QA, but will for production deploys.

