### PR TITLE
Use an .env file for development configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .editorconfig
+.env
 .eslintignore
 .eslintrc
 .git
@@ -10,3 +11,4 @@ Dockerfile
 node_modules
 npm-debug.log
 README.md
+sample.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .editorconfig
+.env
 .sass-cache
 coverage
 docs/public

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ eval $(docker-machine env)
 Running Locally
 ---------------
 
+Before we can run the application, we'll need to create a `.env` file. You can copy the sample file, and consult the documentation for [available options](#configuration):
+
+```sh
+cp sample.env .env
+```
+
 In the working directory, use `docker-compose` to build and start a container. We have some Make tasks which simplify this:
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,5 @@ web:
     - "./deprecated:/app/deprecated"
   ports:
     - "8080:8080"
-  environment:
-    PORT: 8080
-    NODE_ENV: "development"
-    LOG_LEVEL: "trace"
+  env_file: .env
   command: "nodemon --legacy-watch index.js | ./node_modules/.bin/bunyan -o short"

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,4 @@
+# Environment variables for docker-compose
+LOG_LEVEL=trace
+NODE_ENV=development
+PORT=8080


### PR DESCRIPTION
This prevents developers from accidentally committing sensitive information to the repo. Addresses #18.