### PR TITLE
Catch EIA_AGAIN errors and output them as a 502

### DIFF
--- a/lib/express/errorresponse.js
+++ b/lib/express/errorresponse.js
@@ -30,7 +30,7 @@ module.exports = function (err, req, res, next) {
 		} else if (err.code === 'ECONFLICT') {
 			httpStatus = 409;
 			metrics.counter('usererrors.conflict').inc();
-		} else if (err.code === 'EREMOTEIO') {
+		} else if (err.code === 'EREMOTEIO' || err.code === 'EAI_AGAIN') {
 			httpStatus = 502;
 			metrics.counter('servererrors.remoteio').inc();
 		}


### PR DESCRIPTION
EAI_AGAIN means a temporary failure in name resolution, or the name
server returned a temporary failure indication. The solution is to try
again later.

I think this makes the most sense to expose to the user as a 502
"Bad Gateway" error. This will also now get logged to Graphite as a
remote IO error rather than bothering us in Sentry with an error
that we can't actually resolve.

For more information, see:
http://www.codingdefined.com/2015/06/nodejs-error-errno-eaiagain.html