### PR TITLE
Fix shrinkwrap URLs for Git sources

### DIFF
--- a/lib/moduleinstallation.js
+++ b/lib/moduleinstallation.js
@@ -292,6 +292,8 @@ ModuleInstallation.prototype = {
 					version: manifest.version,
 					target: manifest._target,
 					source: manifest._source,
+					originalSource: manifest._originalSource,
+					commit: (manifest._resolution ? manifest._resolution.commit : null)
 					// mainPathOverride can't be exposed here, because the install is shared between overriden and non-overriden sets
 				};
 			}

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -30,7 +30,13 @@ function _createFixedVersionsQueryString(components, filterMethod) {
 	return Object.keys(components).reduce(function(currentValue, componentName) {
 		const componentInfo = components[componentName];
 		const actualVersion = componentInfo.version;
-		const componentVersionTargetString = componentName + '@' + actualVersion;
+		let componentVersionTargetString;
+
+		if (componentInfo.originalSource.indexOf('/') !== -1) {
+			componentVersionTargetString = componentInfo.originalSource;
+		} else {
+			componentVersionTargetString = componentName + '@' + actualVersion;
+		}
 
 		// If the component matches a filter, don't include it in the list
 		if (filterMethod) {

--- a/test/integration/v2-bundles-css.js
+++ b/test/integration/v2-bundles-css.js
@@ -22,7 +22,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with the bundled CSS', function(done) {
-			this.request.expect(`/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=test-ok%40undefined%2Co-autoinit%401.2.0&shrinkwrap=test-dependency%40undefined\n */\n#test-ok{hello:world}#test-dependency{dependency:true}`).end(done);
+			this.request.expect(`/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=mock-modules%2Ftest-ok%2Co-autoinit%401.2.0&shrinkwrap=mock-modules%2Ftest-dependency\n */\n#test-ok{hello:world}#test-dependency{dependency:true}`).end(done);
 		});
 
 		it('should minify the bundle', function(done) {

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -22,7 +22,7 @@ describe('GET /v2/bundles/js', function() {
 		});
 
 		it('should respond with the bundled JavaScript', function(done) {
-			this.request.expect(/^\/\*\* Shrinkwrap URL:\n \*      \/v2\/bundles\/js\?modules=test-ok%40undefined%2Co-autoinit%401.2.0&shrinkwrap=test-dependency%40undefined\n \*\//i).end(done);
+			this.request.expect(/^\/\*\* Shrinkwrap URL:\n \*      \/v2\/bundles\/js\?modules=mock-modules%2Ftest-ok%2Co-autoinit%401.2.0&shrinkwrap=mock-modules%2Ftest-dependency\n \*\//i).end(done);
 		});
 
 		it('should minify the bundle', function(done) {
@@ -73,7 +73,7 @@ describe('GET /v2/bundles/js', function() {
 		});
 
 		it('should respond with the bundled JavaScript without the o-autoinit module', function(done) {
-			this.request.expect(/^\/\*\* Shrinkwrap URL:\n \*      \/v2\/bundles\/js\?modules=test-ok%40undefined&shrinkwrap=test-dependency%40undefined\n \*\//i).end(done);
+			this.request.expect(/^\/\*\* Shrinkwrap URL:\n \*      \/v2\/bundles\/js\?modules=mock-modules%2Ftest-ok&shrinkwrap=mock-modules%2Ftest-dependency\n \*\//i).end(done);
 		});
 
 	});


### PR DESCRIPTION
This is a far-from-ideal fix, because the shrink-wrapped URL for any
bundle that relies on Git sources isn't *technically* shrinkwrapped –
the HEAD of that source will be loaded.

So we're fixing the issue where an incorrect Git source is used for some
shrink-wrapped bundles, but we've uncovered a new issue: shrink-wrapped
bundles aren't always shrink-wrapped :/

I'll open a separate issue for that.

This fixes #26.