### PR TITLE
Update the Build Service hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The Financial Times has published this software under the [MIT license][license]
 
 
 
-[build-service]: https://build.origami.ft.com/
+[build-service]: https://origami-build.ft.com/
 [ci]: https://circleci.com/gh/Financial-Times/origami-build-service
 [developer-spreadsheet]: https://docs.google.com/spreadsheets/d/1mbJQYJOgXAH2KfgKUM1Vgxq8FUIrahumb39wzsgStu0/edit#gid=0
 [docker-compose]: https://docs.docker.com/compose/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ We configure Origami Build Service using environment variables. In development, 
   * `GITHUB_USERNAME`: A GitHub username with permission to view required private repositories.
   * `GITHUB_PASSWORD`: The GitHub password corresponding to `GITHUB_USERNAME`.
   * `METRICS_ENV`: The environment to store metrics under. This defaults to `NODE_ENV`, which allows us to measure QA/production metrics separately.
+  * `PREFERRED_HOSTNAME`: The hostname to use in documentation and as a base URL in bundle requests. This defaults to `origami-build.ft.com`.
 
 
 Testing

--- a/about.json
+++ b/about.json
@@ -3,7 +3,7 @@
 	"name": "build-service",
 	"purpose": "Front end build process as a service.  Fetches specified Origami components from git, runs Origami build process, and returns the resulting CSS or JS bundle over HTTP.",
 	"audience": "public",
-	"primaryUrl": "https://build.origami.ft.com/",
+	"primaryUrl": "https://origami-build.ft.com/",
 	"serviceTier": "gold",
 	"apiVersion": 2,
 	"apiVersions": [

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf8" />
 <title>Origami Build Service</title>
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<link rel="stylesheet" href="https://build.origami.ft.com/v2/bundles/css?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0" />
+<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0" />
 
 <style>
 	html {
@@ -39,7 +39,7 @@
 	}
 </style>
 <script src="//polyfill.webservices.ft.com/v2/polyfill.min.js"></script>
-<script async src="https://build.origami.ft.com/v2/bundles/js?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0"></script>
+<script async src="https://origami-build.ft.com/v2/bundles/js?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0"></script>
 </head>
 <body class="o-techdocs">
 	<header data-o-component="o-header" class="o-header">
@@ -76,8 +76,8 @@
 					<strong>1. Add this snippet in your document to import the <a href="https://git.io/o-grid">grid system</a> and load the FT webfonts:</strong>
 				</p>
 <pre><code>&lt;link rel=&quot;stylesheet&quot;
-	href=&quot;//build.origami.ft.com/v2/bundles/css?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; /&gt;
-&lt;script src=&quot;//build.origami.ft.com/v2/bundles/js?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; async /&gt;</code></pre>
+	href=&quot;//origami-build.ft.com/v2/bundles/css?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; /&gt;
+&lt;script src=&quot;//origami-build.ft.com/v2/bundles/js?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; async /&gt;</code></pre>
 				<p>This is all you need for prototyping with the Build Service. To use the Build Service in production you should also include a <a href="http://origami.ft.com/docs/developer-guide/using-modules/#core-vs-enhanced-experience">cuts the mustard test</a>.
 				<p>
 					<strong>2. Load more modules by adding them to the list:</strong>
@@ -94,12 +94,12 @@
 /v2/bundles/js?modules=o-ads@1.2,o-tracking@3,o-cookiewarn@3.3.1
 /v2/bundles/css?modules=o-signinstatus@1.7.3,o-fonts,o-grid@3</code></pre>
 				<p>You should most likely request all the JS modules you want in a single bundle request, and likewise for CSS, and then write them into the <code>&lt;head&gt;</code> or end of the <code>&lt;body&gt;</code> of your HTML document:</p>
-				<pre><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//build.origami.ft.com/v2/bundles/css?modules=o-ft-nav@2.3,o-tweet@1,colors&quot; /&gt;
-&lt;script src=&quot;//build.origami.ft.com/v2/bundles/js?modules=o-ft-nav@2.3,o-tweet@1,o-tracking@3.5,o-ads@1.2&quot; /&gt;</code></pre>
+				<pre><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//origami-build.ft.com/v2/bundles/css?modules=o-ft-nav@2.3,o-tweet@1,colors&quot; /&gt;
+&lt;script src=&quot;//origami-build.ft.com/v2/bundles/js?modules=o-ft-nav@2.3,o-tweet@1,o-tracking@3.5,o-ads@1.2&quot; /&gt;</code></pre>
 
 				<aside>
 					<h4>Avoiding problems with Content security policy</h4>
-					<p>Although in most cases, <code>link</code> and <code>script</code> tags referencing the build service will be supported by default, in packaged app containers such as Google Chrome extensions, or in web pages served with <a href="http://www.html5rocks.com/en/tutorials/security/content-security-policy/">Content Security Policy</a> headers, you may need to explicitly allow <code>build.origami.ft.com</code> as a source origin from which the app can load resources (see also <a href="https://github.com/Financial-Times/ft-origami/issues/237">issue 237</a>).</p>
+					<p>Although in most cases, <code>link</code> and <code>script</code> tags referencing the build service will be supported by default, in packaged app containers such as Google Chrome extensions, or in web pages served with <a href="http://www.html5rocks.com/en/tutorials/security/content-security-policy/">Content Security Policy</a> headers, you may need to explicitly allow <code>origami-build.ft.com</code> as a source origin from which the app can load resources (see also <a href="https://github.com/Financial-Times/ft-origami/issues/237">issue 237</a>).</p>
 					<ul>
 						<li>Chrome extensions: <a href="https://developer.chrome.com/extensions/contentSecurityPolicy">Update your manifest.json file</a></li>
 					</ul>

--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -7,6 +7,7 @@ const semver = require('semver');
 const toShrinkwrapUrl = require('./shrinkwrap').toUrl;
 const CompileError = require('./utils/compileerror');
 const streamCat = require('streamcat');
+const hostnames = require('./utils/hostnames');
 
 const gulp = require('gulp');
 const obt = require('origami-build-tools');
@@ -177,7 +178,7 @@ CssBundler.prototype = {
 
 		let oAssetsPresent;
 		if (allComponents['o-assets']){
-			variables['o-assets-global-path'] = '//build.origami.ft.com/files/';
+			variables['o-assets-global-path'] = '//' + hostnames.preferred + '/files/';
 			oAssetsPresent = true;
 		}
 

--- a/lib/democompiler.js
+++ b/lib/democompiler.js
@@ -4,11 +4,11 @@ const Q = require('./utils/q');
 const pfs = require('q-io/fs');
 const log = require('./utils/log');
 const FileProxy = require('./fileproxy');
-
 const streamCat = require('streamcat');
 const gulp = require('gulp');
 const obt = require('origami-build-tools');
 const CompileError = require('./utils/compileerror');
+const hostnames = require('./utils/hostnames');
 
 function DemoCompiler() {
 	this.fileProxy = new FileProxy();
@@ -30,7 +30,7 @@ DemoCompiler.prototype = {
 			const demoRelativePath = 'demos/' + options.demoName + '.html';
 			const demoAbsolutePath = installation.getPathToComponentsFile(options.moduleName, demoRelativePath);
 
-			const versionLockedContent = new Buffer(this.fileProxy.versionLockBuildserviceUrls(yield pfs.read(demoAbsolutePath), options.moduleName, options.moduleVersion, 'http://build.origami.ft.com' + options.reqUrl));
+			const versionLockedContent = new Buffer(this.fileProxy.versionLockBuildserviceUrls(yield pfs.read(demoAbsolutePath), options.moduleName, options.moduleVersion, 'https://' + hostnames.preferred + options.reqUrl));
 			return versionLockedContent;
 		} else {
 			const demoBuildPromise = this._doBuild(installation, moduleset, options);
@@ -68,7 +68,7 @@ DemoCompiler.prototype = {
 				if (filesGenerated.length > 0) {
 					log.debug(demoConfig, 'OBT Demo build complete');
 					const html = filesGenerated[0].contents.toString('utf8');
-					const versionLockedContent = this.fileProxy.versionLockBuildserviceUrls(html, options.moduleName, options.moduleVersion, 'http://build.origami.ft.com' + options.reqUrl);
+					const versionLockedContent = this.fileProxy.versionLockBuildserviceUrls(html, options.moduleName, options.moduleVersion, 'https://' + hostnames.preferred + options.reqUrl);
 					resolve(new Buffer(versionLockedContent));
 				} else {
 					reject(new CompileError('No file were generated running obt.demo'));

--- a/lib/fileproxy.js
+++ b/lib/fileproxy.js
@@ -9,6 +9,7 @@ const pfs = require('q-io/fs');
 const cheerio = require('cheerio');
 const ModuleSet = require('./moduleset');
 const HTTPError = require('./express/httperror');
+const hostnames = require('./utils/hostnames');
 
 function FileProxy(options) {
 	options = options || {};
@@ -21,7 +22,7 @@ FileProxy.prototype = {
 		if (doVersionLock) {
 			const installed = yield fileInfo.installation.list(fileInfo.moduleset);
 			const componentName = Object.keys(installed)[0];
-			return new Buffer(this.versionLockBuildserviceUrls(yield pfs.read(fileInfo.path), componentName, installed[componentName].version, 'http://build.origami.ft.com' + reqUrl));
+			return new Buffer(this.versionLockBuildserviceUrls(yield pfs.read(fileInfo.path), componentName, installed[componentName].version, 'https://' + hostnames.preferred + reqUrl));
 		} else {
 			return fs.createReadStream(fileInfo.path);
 		}
@@ -57,9 +58,7 @@ FileProxy.prototype = {
 	_versionLockUrl: function(urlStr, componentName, actualVersion, baseURL) {
 		const url = URL.parse(URL.resolve(baseURL, urlStr), true, true);
 
-		if ((url.hostname === 'build.origami.ft.com' || url.hostname === 'buildservice.ft.com')
-				&& /\/bundles\/(?:css|js)\?/.test(url.path)) {
-
+		if (hostnames.known.indexOf(url.hostname) !== -1 && /\/bundles\/(?:css|js)\?/.test(url.path)) {
 			if (url.query.modules) {
 				const moduleset = new ModuleSet(url.query.modules.split(','));
 				moduleset.getResolvedModules().forEach(function(m){

--- a/lib/jsbundler.js
+++ b/lib/jsbundler.js
@@ -6,6 +6,7 @@ const path = require('path');
 const CompileError = require('./utils/compileerror');
 const toShrinkwrapUrl = require('./shrinkwrap').toUrl;
 const uniqueid = require('./utils/uniqueid');
+const hostnames = require('./utils/hostnames');
 
 const streamCat = require('streamcat');
 const log = require('./utils/log');
@@ -72,7 +73,7 @@ JsBundler.prototype = {
 				}
 			}
 
-			const assetsSource = ('o-assets' in allComponents) ? 'require(\'o-assets\').setGlobalPathPrefix(\'//build.origami.ft.com/files/\').setModuleVersions(' + JSON.stringify(moduleVersions) + ');' : '';
+			const assetsSource = ('o-assets' in allComponents) ? 'require(\'o-assets\').setGlobalPathPrefix(\'//' + hostnames.preferred + '/files/\').setModuleVersions(' + JSON.stringify(moduleVersions) + ');' : '';
 
 			// if exportName is defined generate window["exportName"] = {}, otherwise just rows of require();
 			const importsSource = options.exportName ? 'window['+JSON.stringify(options.exportName)+'] = {' + requires.join(',\n') + '}' : requires.join('\n');

--- a/lib/routes/bundles.js
+++ b/lib/routes/bundles.js
@@ -27,7 +27,7 @@ module.exports = function(app, config) {
 			})
 			.catch(() => {
 				const redirectUrl = '/v2/bundles/' + req.params.type + URL.parse(req.url).search;
-				const redirectBody = 'This endpoint has been deprecated. You are being redirected to ' + redirectUrl + '\nSee http://build.origami.ft.com/v2/#api-reference for more information.';
+				const redirectBody = 'This endpoint has been deprecated. You are being redirected to ' + redirectUrl + '\nSee https://origami-build.ft.com/v2/#api-reference for more information.';
 
 				// Note: we can't use `res.redirect` here because it doesn't allow
 				// modifications to the response body.

--- a/lib/routes/bundles.js
+++ b/lib/routes/bundles.js
@@ -4,6 +4,7 @@ const getStaticBundleStream = require('../../deprecated/static-bundle').getStati
 const metrics = require('../monitoring/metrics');
 const redirectWithBody = require('../express/redirect-with-body');
 const URL = require('url');
+const hostnames = require('../utils/hostnames');
 
 module.exports = function(app, config) {
 	const buildSystem = config.buildSystem;
@@ -27,7 +28,7 @@ module.exports = function(app, config) {
 			})
 			.catch(() => {
 				const redirectUrl = '/v2/bundles/' + req.params.type + URL.parse(req.url).search;
-				const redirectBody = 'This endpoint has been deprecated. You are being redirected to ' + redirectUrl + '\nSee https://origami-build.ft.com/v2/#api-reference for more information.';
+				const redirectBody = 'This endpoint has been deprecated. You are being redirected to ' + redirectUrl + '\nSee https://' + hostnames.preferred + '/v2/#api-reference for more information.';
 
 				// Note: we can't use `res.redirect` here because it doesn't allow
 				// modifications to the response body.

--- a/lib/utils/hostnames.js
+++ b/lib/utils/hostnames.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // We only want one reference to the hostname in the code
-exports.preferred = process.env.PREFERRED_HOSTNAME || 'build.origami.ft.com';
+exports.preferred = process.env.PREFERRED_HOSTNAME || 'origami-build.ft.com';
 
 // A list of the hostnames that we know can hit the build service
 exports.known = [

--- a/lib/utils/hostnames.js
+++ b/lib/utils/hostnames.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// We only want one reference to the hostname in the code
+exports.preferred = process.env.PREFERRED_HOSTNAME || 'build.origami.ft.com';
+
+// A list of the hostnames that we know can hit the build service
+exports.known = [
+	'build.origami.ft.com',
+	'buildservice-fastly.ft.com',
+	'buildservice.ft.com',
+	'origami-build.ft.com',
+	'origami-buildservice-eu.herokuapp.com',
+	'origami-buildservice-qa.herokuapp.com'
+];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "buildservice",
   "description": "Origami build service",
   "version": "3.3.3",
-  "homepage": "http://build.origami.ft.com/",
+  "homepage": "https://origami-build.ft.com/",
   "keywords": [
     "origami"
   ],

--- a/test/assetstest.js
+++ b/test/assetstest.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const testhelper = require('./testhelper');
 const JsBundler = testhelper.JsBundler;
+const hostnames = require('../lib/utils/hostnames');
 
 const log = testhelper.log;
 const ModuleInstallation = testhelper.ModuleInstallation;
@@ -33,7 +34,7 @@ suite('assets', function(){
 
 		assert.include(js, 'o-assets');
 		assert.include(js, 'setGlobalPathPrefix');
-		assert.include(js, '//build.origami.ft.com/files/');
+		assert.include(js, '//' + hostnames.preferred + '/files/');
 	});
 
 });

--- a/test/bundlercsstest.js
+++ b/test/bundlercsstest.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 const testhelper = require('./testhelper');
 const CssBundler = testhelper.CssBundler;
+const hostnames = require('../lib/utils/hostnames');
 
 const log = testhelper.log;
 const ModuleInstallation = testhelper.ModuleInstallation;
@@ -19,7 +20,7 @@ suiteWithPackages('installation-css has_external_dependency', ['invalidcss', 'te
 		const css = yield testhelper.bufferStream(yield (new CssBundler({log:log})).getContent(installation, moduleset,{minify:true}));
 
 		const cssWithoutShrink = css.replace(/\/\*.*Shrinkwrap[\s\S]+?\*\/\s*/,'');
-		assert.equal(cssWithoutShrink, '#test1{hello:world;silent-var:false;url:url(//build.origami.ft.com/files/test-package1@*/README)}');
+		assert.equal(cssWithoutShrink, '#test1{hello:world;silent-var:false;url:url(//' + hostnames.preferred + '/files/test-package1@*/README)}');
 	});
 
 	spawnTest('invalid-sass', function*(){

--- a/test/testmodules/html/demo.html
+++ b/test/testmodules/html/demo.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <link rel="foo"
-	href="http://build.origami.ft.com/files/html/css.css">
-<link rel="foo" href="http://build.origami.ft.com/files/html@0.1/no-change.css">
+	href="http://origami-build.ft.com/files/html/css.css">
+<link rel="foo" href="http://origami-build.ft.com/files/html@0.1/no-change.css">
 
 <link rel="stylesheet"
-href=http://build.origami.ft.com/v2/bundles/css?modules=yup@1,html,foo@* >
+href=http://origami-build.ft.com/v2/bundles/css?modules=yup@1,html,foo@* >
 <link rel="stylesheet"
 href=/v2/bundles/css?modules=relative@1,html:/withfile,foo@* >
 <img
-src=http://build.origami.ft.com/v2/bundles/css?modules=nope@1,html,foo@* >
-<img src="http://build.origami.ft.com/v2/bundles/css?modules=bar-html,html@*,nochange@*">
+src=http://origami-build.ft.com/v2/bundles/css?modules=nope@1,html,foo@* >
+<img src="http://origami-build.ft.com/v2/bundles/css?modules=bar-html,html@*,nochange@*">
 
 <script
-src="http://build.origami.ft.com/v2/bundles/js?modules=html2@v1.0,html,foo@*">
+src="http://origami-build.ft.com/v2/bundles/js?modules=html2@v1.0,html,foo@*">
 </script>
 <script
-src='http://build.origami.ft.com/v2/bundles/js?otherargs=zzz&amp;modules=singlequotes,html'></script>
+src='http://origami-build.ft.com/v2/bundles/js?otherargs=zzz&amp;modules=singlequotes,html'></script>
 
 
 <script

--- a/test/testmodules/html/demo.html
+++ b/test/testmodules/html/demo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <link rel="foo"
-	href="http://buildservice.ft.com/files/html/css.css">
+	href="http://build.origami.ft.com/files/html/css.css">
 <link rel="foo" href="http://build.origami.ft.com/files/html@0.1/no-change.css">
 
 <link rel="stylesheet"


### PR DESCRIPTION
:warning: **maybe don't merge until we've discussed as a team** :warning: 

This updates the hostname across the build service from `build.origami.ft.com` to `origami-build.ft.com`. I've made a few code changes as well to make this process simpler in future:

  * Moved all hostname references in the code to a single file
  * Reduce how much the tests rely on a specific hostname

There are some important gotchas to consider before we merge this:

#### Asset paths

Because of the way asset paths are added into the output bundles, every bundle will now request assets through Fastly rather than Akamai (even if the bundle itself is requested through Akamai).

E.g. a request to <code>http://<b>build.origami.ft.com</b>/v2/bundles/css?modules=o-icons</code> (Akamai-served) will contain the following font source (Fastly-served):

<pre>
@font-face{font-family:ft-icons;src:url(//<b>origami-build.ft.com</b>/files/o-ft-ico...
</pre>

This _shouldn't_ cause any issues, but it's a more broad test of Fastly than we were originally anticipating. We'll need a fair amount of testing in QA before we can confidently promote to production.

#### New URLs

Any new Build Service requests from this point onwards will go through Fastly, because all of the documentation has been updated to use the new URL.