### PR TITLE
Make the documentation hostname configurable

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf8" />
 <title>Origami Build Service</title>
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0" />
+<link rel="stylesheet" href="https://{{build-service-hostname}}/v2/bundles/css?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0" />
 
 <style>
 	html {
@@ -39,7 +39,7 @@
 	}
 </style>
 <script src="//polyfill.webservices.ft.com/v2/polyfill.min.js"></script>
-<script async src="https://origami-build.ft.com/v2/bundles/js?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0"></script>
+<script async src="https://{{build-service-hostname}}/v2/bundles/js?modules=o-techdocs@^5.0.0,o-fonts@^1.4.0,o-grid@^4.0.0,o-ft-icons@^3.2.0"></script>
 </head>
 <body class="o-techdocs">
 	<header data-o-component="o-header" class="o-header">
@@ -76,8 +76,8 @@
 					<strong>1. Add this snippet in your document to import the <a href="https://git.io/o-grid">grid system</a> and load the FT webfonts:</strong>
 				</p>
 <pre><code>&lt;link rel=&quot;stylesheet&quot;
-	href=&quot;//origami-build.ft.com/v2/bundles/css?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; /&gt;
-&lt;script src=&quot;//origami-build.ft.com/v2/bundles/js?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; async /&gt;</code></pre>
+	href=&quot;//{{build-service-hostname}}/v2/bundles/css?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; /&gt;
+&lt;script src=&quot;//{{build-service-hostname}}/v2/bundles/js?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; async /&gt;</code></pre>
 				<p>This is all you need for prototyping with the Build Service. To use the Build Service in production you should also include a <a href="http://origami.ft.com/docs/developer-guide/using-modules/#core-vs-enhanced-experience">cuts the mustard test</a>.
 				<p>
 					<strong>2. Load more modules by adding them to the list:</strong>
@@ -94,12 +94,12 @@
 /v2/bundles/js?modules=o-ads@1.2,o-tracking@3,o-cookiewarn@3.3.1
 /v2/bundles/css?modules=o-signinstatus@1.7.3,o-fonts,o-grid@3</code></pre>
 				<p>You should most likely request all the JS modules you want in a single bundle request, and likewise for CSS, and then write them into the <code>&lt;head&gt;</code> or end of the <code>&lt;body&gt;</code> of your HTML document:</p>
-				<pre><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//origami-build.ft.com/v2/bundles/css?modules=o-ft-nav@2.3,o-tweet@1,colors&quot; /&gt;
-&lt;script src=&quot;//origami-build.ft.com/v2/bundles/js?modules=o-ft-nav@2.3,o-tweet@1,o-tracking@3.5,o-ads@1.2&quot; /&gt;</code></pre>
+				<pre><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//{{build-service-hostname}}/v2/bundles/css?modules=o-ft-nav@2.3,o-tweet@1,colors&quot; /&gt;
+&lt;script src=&quot;//{{build-service-hostname}}/v2/bundles/js?modules=o-ft-nav@2.3,o-tweet@1,o-tracking@3.5,o-ads@1.2&quot; /&gt;</code></pre>
 
 				<aside>
 					<h4>Avoiding problems with Content security policy</h4>
-					<p>Although in most cases, <code>link</code> and <code>script</code> tags referencing the build service will be supported by default, in packaged app containers such as Google Chrome extensions, or in web pages served with <a href="http://www.html5rocks.com/en/tutorials/security/content-security-policy/">Content Security Policy</a> headers, you may need to explicitly allow <code>origami-build.ft.com</code> as a source origin from which the app can load resources (see also <a href="https://github.com/Financial-Times/ft-origami/issues/237">issue 237</a>).</p>
+					<p>Although in most cases, <code>link</code> and <code>script</code> tags referencing the build service will be supported by default, in packaged app containers such as Google Chrome extensions, or in web pages served with <a href="http://www.html5rocks.com/en/tutorials/security/content-security-policy/">Content Security Policy</a> headers, you may need to explicitly allow <code>{{build-service-hostname}}</code> as a source origin from which the app can load resources (see also <a href="https://github.com/Financial-Times/ft-origami/issues/237">issue 237</a>).</p>
 					<ul>
 						<li>Chrome extensions: <a href="https://developer.chrome.com/extensions/contentSecurityPolicy">Update your manifest.json file</a></li>
 					</ul>

--- a/lib/routes/docs.js
+++ b/lib/routes/docs.js
@@ -3,23 +3,25 @@
 const fs = require('fs');
 const path = require('path');
 const oneWeek = 60 * 60 * 24 * 7;
+const hostnames = require('../utils/hostnames');
 
 module.exports = function(app, config) {
 
 	const docsDirectory = config.docsDirectory || path.join(__dirname, '/../../docs');
+	const pathToDocsFile = path.join(docsDirectory, 'index.html');
+
+	// Sync operation only happens once during startup
+	let documentation = fs.readFileSync(pathToDocsFile, 'utf-8');
+	documentation = documentation.replace(/\{\{build-service-hostname\}\}/g, hostnames.preferred);
 
 	app.get('/', (req, res) => res.redirect('/v2/'));
 	app.get('/v1/', (req, res) => res.redirect('/v2/'));
 
 	app.get('/v2/', (req, res) => {
-
-		const pathToDocsFile = path.join(docsDirectory, 'index.html');
-
 		res.set({
 			'Content-Type': 'text/html',
 			'Cache-Control': 'public, stale-while-revalidate=' + oneWeek + ', max-age=' + oneWeek
 		});
-
-		fs.createReadStream(pathToDocsFile).pipe(res);
+		res.send(documentation);
 	});
 };

--- a/test/integration/v2.js
+++ b/test/integration/v2.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const request = require('supertest');
+const hostnames = require('../../lib/utils/hostnames');
 
 describe('GET /v2', function() {
 	this.timeout(20000);
@@ -23,6 +24,7 @@ describe('GET /v2', function() {
 
 	it('should respond with the build service documentation', function(done) {
 		fs.readFile(`${__dirname}/../../docs/index.html`, 'utf-8', (error, content) => {
+			content = content.replace(/\{\{build-service-hostname\}\}/g, hostnames.preferred);
 			this.request.expect(content).end(done);
 		});
 	});


### PR DESCRIPTION
I don't know how I feel about this, it _could_ be a bit misleading to use Mustache-style syntax for this replacement. What do you think?

This is so we can quickly and easily switch between Fastly and Akamai in the documentation as well as the app. So I can safely deploy the change to the preferred hostname and roll back in seconds if anything goes wrong.