### PR TITLE
Babel disable

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -171,9 +171,9 @@ o-typography:
 						<td>Querystring</td>
 						<td><em>(Optional)</em> If present and set to 'none', suppresses minification.  Otherwise output will be minified automatically.</td>
 					</tr><tr>
-						<td><code>babel</code></td>
+						<td><code>polyfills</code></td>
 						<td>Querystring</td>
-						<td><em>(Optional)</em> If present and set to 'none', does not add Babel polyfills to the output. Use this if your bundle is conflicting with other polyfills (e.g. through the <a href="https://cdn.polyfill.io/">Polyfill Service</a>).</td>
+						<td><em>(Optional)</em> If present and set to 'none', does not add polyfills to the output. Use this if your bundle is conflicting with other polyfills (e.g. through the <a href="https://cdn.polyfill.io/">Polyfill Service</a>).</td>
 					</tr><tr>
 						<td><code>export</code></td>
 						<td>Querystring</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -171,6 +171,10 @@ o-typography:
 						<td>Querystring</td>
 						<td><em>(Optional)</em> If present and set to 'none', suppresses minification.  Otherwise output will be minified automatically.</td>
 					</tr><tr>
+						<td><code>babel</code></td>
+						<td>Querystring</td>
+						<td><em>(Optional)</em> If present and set to 'none', does not add Babel polyfills to the output. Use this if your bundle is conflicting with other polyfills (e.g. through the <a href="https://cdn.polyfill.io/">Polyfill Service</a>).</td>
+					</tr><tr>
 						<td><code>export</code></td>
 						<td>Querystring</td>
 						<td><em>(Optional)</em> If present, generates a <a href="https://github.com/umdjs/umd">UMD</a> bundle for the supplied export name. UMD works with other module systems and if no module system is found sets the specified name as a window global.  If absent, the default export name <code>Origami</code> will be used.  To export nothing, pass an empty string.</td>

--- a/lib/buildsystem.js
+++ b/lib/buildsystem.js
@@ -32,7 +32,7 @@ function getBundleDetails(req) {
 	}
 
 	return {
-		babelRuntime:       req.query.babel ? stringToBoolean(req.query.babel) : true,
+		babelRuntime:       req.query.polyfills ? stringToBoolean(req.query.polyfills) : true,
 		newerThan:          req.query.newerthan ? Date.parse(req.query.newerthan) : false,
 		modules:            new ModuleSet(modules),
 		versionLocks:       req.query.shrinkwrap ? new ModuleSet(req.query.shrinkwrap.split(/\s*,\s*/)) : false,

--- a/lib/buildsystem.js
+++ b/lib/buildsystem.js
@@ -12,6 +12,7 @@ const utils = require('./utils');
 const HTTPError = require('./express/httperror');
 const CompileError = require('./utils/compileerror');
 const metrics = require('./monitoring/metrics');
+const stringToBoolean = require('./utils/string-to-boolean');
 
 const oneHourMSec = 3600 * 1000;
 const timeoutDurationMSec = 20000;
@@ -31,6 +32,7 @@ function getBundleDetails(req) {
 	}
 
 	return {
+		babelRuntime:       req.query.babel ? stringToBoolean(req.query.babel) : true,
 		newerThan:          req.query.newerthan ? Date.parse(req.query.newerthan) : false,
 		modules:            new ModuleSet(modules),
 		versionLocks:       req.query.shrinkwrap ? new ModuleSet(req.query.shrinkwrap.split(/\s*,\s*/)) : false,

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -31,7 +31,7 @@ Bundler.prototype = {
 			type + '.' +
 			'v2.' +
 			'min:' + opts.minify + '.' +
-			'babel:' + opts.babelRuntime + '.' +
+			'polyfills:' + opts.babelRuntime + '.' +
 			((typeof options.exportName === 'string' )? uniqueid(options.exportName, 64) : 'noexportname')
 		;
 

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -30,7 +30,8 @@ Bundler.prototype = {
 			(opts.demoName ? opts.demoName + '.' : '') +
 			type + '.' +
 			'v2.' +
-			opts.minify + '.' +
+			'min:' + opts.minify + '.' +
+			'babel:' + opts.babelRuntime + '.' +
 			((typeof options.exportName === 'string' )? uniqueid(options.exportName, 64) : 'noexportname')
 		;
 

--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -31,14 +31,14 @@ function isCssPath(path) {
 
 CssBundler.prototype = {
 
-	createShrinkWrapComment: function(installation, moduleset) {
+	createShrinkWrapComment: function(installation, moduleset, options) {
 		return Promise.all([
 			installation.listAll(),
 			installation.getInstalledInModuleset(moduleset)
 		]).then(function(results) {
 			const allOrigamiComponents = results[0];
 			const requestedComponents = results[1];
-			return toShrinkwrapUrl('css', requestedComponents, allOrigamiComponents, 'v2');
+			return toShrinkwrapUrl('css', requestedComponents, allOrigamiComponents, 'v2', options);
 		}).then(function(shrinkwrapUrl) {
 			return new Buffer('/** Shrinkwrap URL:\n *    ' + shrinkwrapUrl + '\n */\n');
 		});
@@ -96,7 +96,7 @@ CssBundler.prototype = {
 		const buildOutputName = 'build-' + moduleset.getMainPathOverridesIdentifier() + '.js';
 
 		const mainFilePromise = this.createMainFile(installation, moduleset, mainSassPath, opts);
-		const shrinkwrapPromise = this.createShrinkWrapComment(installation, moduleset);
+		const shrinkwrapPromise = this.createShrinkWrapComment(installation, moduleset, opts);
 		const bundlePromise = this._doBuild(installation, mainFilePromise, path.join(buildOutputPath, '/build'), buildOutputName, opts);
 
 

--- a/lib/jsbundler.js
+++ b/lib/jsbundler.js
@@ -18,7 +18,7 @@ function JsBundler() {}
 
 JsBundler.prototype = {
 
-	createShrinkWrapComment: function(installation, moduleset) {
+	createShrinkWrapComment: function(installation, moduleset, options) {
 		return Promise.all([
 			installation.listAll(),
 			installation.getInstalledInModuleset(moduleset)
@@ -26,7 +26,7 @@ JsBundler.prototype = {
 			const allOrigamiComponents = results[0];
 			const requestedComponents = results[1];
 
-			return new Buffer('/** Shrinkwrap URL:\n *      ' + (toShrinkwrapUrl('js', requestedComponents, allOrigamiComponents, 'v2')) + '\n */\n');
+			return new Buffer('/** Shrinkwrap URL:\n *      ' + (toShrinkwrapUrl('js', requestedComponents, allOrigamiComponents, 'v2', options)) + '\n */\n');
 		});
 	},
 
@@ -113,7 +113,7 @@ JsBundler.prototype = {
 		const buildOutputName = 'build-' + moduleset.getMainPathOverridesIdentifier() + '.js';
 
 		const mainFilePromise = this.createMainFile(installation, moduleset, mainScriptPath, opts);
-		const skrinkWrapBufferPromise = this.createShrinkWrapComment(installation, moduleset);
+		const skrinkWrapBufferPromise = this.createShrinkWrapComment(installation, moduleset, opts);
 		const jsBundlePromise = this._doBuild(installation, mainFilePromise, relativeMainScriptPath, path.join(buildOutputPath, '/build'), buildOutputName, opts);
 
 		// Concatenate buffers and streams in order asynchronously, returns a
@@ -139,7 +139,8 @@ JsBundler.prototype = {
 				env: options.minify ? 'production' : 'development',
 				cwd: installation.getDirectory(),
 				basedir: installation.getDirectory(),
-				sourcemaps: options.minify ? false : 'inline'
+				sourcemaps: options.minify ? false : 'inline',
+				babelRuntime: options.babelRuntime
 			};
 			log.trace(config, 'Starting OBT JS build');
 			const buildStream = obt.build.js(gulp, config);

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -17,7 +17,7 @@ module.exports.toUrl = function(bundleType, requestedComponents, allComponents, 
 		})
 	};
 	if (opts.babelRuntime === false) {
-		query.babel = 'false';
+		query.polyfills = 'false';
 	}
 
 	const url = {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -8,13 +8,17 @@ const URL = require('url');
  * components, creates a String that represents the URL that shrinkwraps the
  * installation.
  */
-module.exports.toUrl = function(bundleType, requestedComponents, allComponents, endpointVersion) {
+module.exports.toUrl = function(bundleType, requestedComponents, allComponents, endpointVersion, options) {
+	const opts = options || {};
 	const query = {
 		modules: _createFixedVersionsQueryString(requestedComponents),
 		shrinkwrap: _createFixedVersionsQueryString(allComponents, function(componentName) {
 			return componentName in requestedComponents;
 		})
 	};
+	if (opts.babelRuntime === false) {
+		query.babel = 'false';
+	}
 
 	const url = {
 		host: '',

--- a/lib/utils/string-to-boolean.js
+++ b/lib/utils/string-to-boolean.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const falsyValues = [
+    '0',
+    'false',
+    'no',
+    'none'
+];
+
+function stringToBoolean(string) {
+	if (falsyValues.indexOf(string.trim()) >= 0) {
+        return false;
+    }
+    return Boolean(string);
+}
+
+module.exports = stringToBoolean;

--- a/test/integration/mock-modules/test-ok/main.js
+++ b/test/integration/mock-modules/test-ok/main.js
@@ -3,3 +3,4 @@
 // unminified
 const testOk = true;
 const dependency = require('test-dependency');
+const symbol = Symbol('foo');

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -121,6 +121,48 @@ describe('GET /v2/bundles/js', function() {
 
 	});
 
+	describe('when a valid module is requested (with the `babel` parameter set to `none`)', function() {
+		const moduleName = 'mock-modules/test-ok';
+
+		beforeEach(function() {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&babel=none&minify=none`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function(done) {
+			this.request.expect(200).end(done);
+		});
+
+		it('should respond with the bundled JavaScript with no Babel polyfills', function(done) {
+			this.request.expect(function(response) {
+				assert.notMatch(response.text, /Array\.isArray/);
+			}).end(done);
+		});
+
+	});
+
+	describe('when a valid module is requested (with the `babel` parameter set to `true`)', function() {
+		const moduleName = 'mock-modules/test-ok';
+
+		beforeEach(function() {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&babel=true&minify=none`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function(done) {
+			this.request.expect(200).end(done);
+		});
+
+		it('should respond with the bundled JavaScript containing Babel polyfills', function(done) {
+			this.request.expect(/Array\.isArray/).end(done);
+		});
+
+	});
+
 	describe('when an invalid module is requested (nonexistent)', function() {
 		const moduleName = 'mock-modules/test-404';
 

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -121,13 +121,13 @@ describe('GET /v2/bundles/js', function() {
 
 	});
 
-	describe('when a valid module is requested (with the `babel` parameter set to `none`)', function() {
+	describe('when a valid module is requested (with the `polyfills` parameter set to `none`)', function() {
 		const moduleName = 'mock-modules/test-ok';
 
 		beforeEach(function() {
 			const now = (new Date()).toISOString();
 			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&babel=none&minify=none`)
+				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&polyfills=none&minify=none`)
 				.set('Connection', 'close');
 		});
 
@@ -135,7 +135,7 @@ describe('GET /v2/bundles/js', function() {
 			this.request.expect(200).end(done);
 		});
 
-		it('should respond with the bundled JavaScript with no Babel polyfills', function(done) {
+		it('should respond with the bundled JavaScript with no polyfills', function(done) {
 			this.request.expect(function(response) {
 				assert.notMatch(response.text, /Array\.isArray/);
 			}).end(done);
@@ -143,13 +143,13 @@ describe('GET /v2/bundles/js', function() {
 
 	});
 
-	describe('when a valid module is requested (with the `babel` parameter set to `true`)', function() {
+	describe('when a valid module is requested (with the `polyfills` parameter set to `true`)', function() {
 		const moduleName = 'mock-modules/test-ok';
 
 		beforeEach(function() {
 			const now = (new Date()).toISOString();
 			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&babel=true&minify=none`)
+				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&polyfills=true&minify=none`)
 				.set('Connection', 'close');
 		});
 
@@ -157,7 +157,7 @@ describe('GET /v2/bundles/js', function() {
 			this.request.expect(200).end(done);
 		});
 
-		it('should respond with the bundled JavaScript containing Babel polyfills', function(done) {
+		it('should respond with the bundled JavaScript containing polyfills', function(done) {
 			this.request.expect(/Array\.isArray/).end(done);
 		});
 

--- a/test/moduleinstallationtest.js
+++ b/test/moduleinstallationtest.js
@@ -96,8 +96,8 @@ suite('installation-remote', function() {
 
 		const css = yield testhelper.bufferStream(cssStream);
 
-		assert.notInclude(css, 'o-ft-icons/build/ft-icons');
-		assert.include(css, 'o-ft-icons@', 'Subresource needs to be versioned');
+		assert.notInclude(css, 'o-icons/build/ft-icons');
+		assert.include(css, 'o-icons%40', 'Subresource needs to be versioned');
 	});
 
 	spawnTestWithTempdir('install-external nonexistant-module', function*(tmpdir) {

--- a/test/unit/lib/utils/string-to-boolean.test.js
+++ b/test/unit/lib/utils/string-to-boolean.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const assert = require('chai').assert;
+
+describe('lib/utils/string-to-boolean', function() {
+	let stringToBoolean;
+
+	beforeEach(function() {
+		stringToBoolean = require('../../../../lib/utils/string-to-boolean');
+	});
+
+	it('should export a function', function() {
+		assert.isFunction(stringToBoolean);
+	});
+
+	describe('stringToBoolean(string)', function() {
+		let boolean;
+
+		describe('when `string` is "true"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('true');
+			});
+
+			it('returns `true`', function() {
+				assert.isTrue(boolean);
+			});
+
+		});
+
+		describe('when `string` is "yes"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('yes');
+			});
+
+			it('returns `true`', function() {
+				assert.isTrue(boolean);
+			});
+
+		});
+
+		describe('when `string` is "1"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('1');
+			});
+
+			it('returns `true`', function() {
+				assert.isTrue(boolean);
+			});
+
+		});
+
+		describe('when `string` is "false"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('false');
+			});
+
+			it('returns `false`', function() {
+				assert.isFalse(boolean);
+			});
+
+		});
+
+		describe('when `string` is "no"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('no');
+			});
+
+			it('returns `false`', function() {
+				assert.isFalse(boolean);
+			});
+
+		});
+
+		describe('when `string` is "0"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('0');
+			});
+
+			it('returns `false`', function() {
+				assert.isFalse(boolean);
+			});
+
+		});
+
+		describe('when `string` is "none"', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('none');
+			});
+
+			it('returns `false`', function() {
+				assert.isFalse(boolean);
+			});
+
+		});
+
+		describe('when `string` is empty', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('');
+			});
+
+			it('returns `false`', function() {
+				assert.isFalse(boolean);
+			});
+
+		});
+
+		describe('when `string` is any other value', function() {
+
+			beforeEach(function() {
+				boolean = stringToBoolean('foobar');
+			});
+
+			it('returns `true`', function() {
+				assert.isTrue(boolean);
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This adds a `babel` parameter to the `/v2/bundles/js` endpoint which can be used to switch off Babel polyfills. It maps to the [`babelRuntime`](https://github.com/Financial-Times/origami-build-tools/pull/354/) option in OBT, and can be set to `none` or another falsy value. It defaults to `true`.

I'm happy to change the name of the parameter if this one isn't descriptive enough, or there's another name that makes more sense.

This PR resolves #58.