### PR TITLE
Correct health checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ const buildSystem = new BuildSystem({
 		severity: 1,
 		checkPeriod: 120,
 		technicalSummary: 'Process has run out of available memory',
-		panicGuide: 'Restart the service on `' + hostname + '`, Try: `ssh ' + hostname + '`, then `sudo service buildservice restart` and re-check health status for `' + hostname + ':8080/__health`'
+		panicGuide: 'Restart the service using the `heroku` command line tool: `heroku restart --app origami-buildservice-eu`.'
 	});
 
 	dirInitialised.then(function() {
@@ -149,7 +149,7 @@ const buildSystem = new BuildSystem({
 			severity: 1,
 			checkPeriod: 120,
 			technicalSummary: '/tmp directory is full, new modules will not be installable.',
-			panicGuide: 'Restart the service on `' + hostname + '`, Try: `ssh ' + hostname + '`, then `sudo service buildservice restart` and re-check health status for `' + hostname + ':8080/__health`',
+			panicGuide: 'Restart the service using the `heroku` command line tool: `heroku restart --app origami-buildservice-eu`.',
 			businessImpact: 'New modules will not be able to install and existing modules will not refresh.  As problem persists expect end user reports from critical sites regarding styling and broken functionality.'
 		}, tempdir);
 	});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bunyan": "^1.5.1",
     "cheerio": "^0.17.0",
     "commander": "^2.3.0",
-    "diskspace": "git+http://github.com/Financial-Times/diskspace.js.git#alpine",
+    "diskspace": "git+http://github.com/Financial-Times/diskspace.js.git",
     "express": "^4.12.3",
     "express-ftwebservice": "^2.0.2",
     "glob": "^4.0.5",


### PR DESCRIPTION
The panic guides for memory/disk usage were out of date.
Also, now that we're no longer using Alpine Node on Docker,
we need to revert back to the regular diskspace module.