### PR TITLE
Modulemeta demo design guidance

### DIFF
--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -86,7 +86,6 @@ ModuleMetadata.prototype = {
 			}
 
 			// Saves Origami Registry hassle of finding and downloading the README.
-			// TODO:KL: instead of mixing text/markdown add type information or convert all to text/html
 			const readmeFilenames = ['README.md', 'readme.md', 'README', 'readme.txt', 'README.txt'];
 			metadata.readme = yield this._getFileFromList(readmeFilenames, module, installation);
 

--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -89,6 +89,9 @@ ModuleMetadata.prototype = {
 			const readmeFilenames = ['README.md', 'readme.md', 'README', 'readme.txt', 'README.txt'];
 			metadata.readme = yield this._getFileFromList(readmeFilenames, module, installation);
 
+			const designGuidelinesFilenames = ['designguidelines.md', 'usage.md', 'examples.md', 'demos.md'];
+			metadata.designGuidelines = yield this._getFileFromList(demoGuideFilenames, module, installation);
+
 		} catch(e) {
 			// if top-level module is not found that's 404 for the entire API
 			const endpoint = e.endpoint || (e.data && e.data.endpoint);

--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -23,6 +23,8 @@ ModuleMetadata.prototype = {
 				}
 			}
 		}
+
+		return false;
 	}),
 
 	/**
@@ -90,7 +92,7 @@ ModuleMetadata.prototype = {
 			metadata.readme = yield this._getFileFromList(readmeFilenames, module, installation);
 
 			const designGuidelinesFilenames = ['designguidelines.md', 'usage.md', 'examples.md', 'demos.md'];
-			metadata.designGuidelines = yield this._getFileFromList(demoGuideFilenames, module, installation);
+			metadata.designGuidelines = yield this._getFileFromList(designGuidelinesFilenames, module, installation);
 
 		} catch(e) {
 			// if top-level module is not found that's 404 for the entire API

--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -12,6 +12,19 @@ function ModuleMetadata(options) {
 }
 
 ModuleMetadata.prototype = {
+
+	_getFileFromList: Q.async(function*(filenames, module, installation) {
+		for(let i in filenames) {
+			if (filenames.hasOwnProperty(i)) {
+				const path = installation.getPathToComponentsFile(module.endpoint.name, filenames[i]);
+				if (yield pfs.exists(path)) {
+					const fileContents = yield pfs.read(path);
+					return fileContents;
+				}
+			}
+		}
+	}),
+
 	/**
 	 * Fetch module, test whether it builds, include manifests, readme, etc.
 	 */
@@ -74,16 +87,8 @@ ModuleMetadata.prototype = {
 
 			// Saves Origami Registry hassle of finding and downloading the README.
 			// TODO:KL: instead of mixing text/markdown add type information or convert all to text/html
-			const filenames = ['README.md', 'readme.md', 'README', 'readme.txt', 'README.txt'];
-			for(let i in filenames) {
-				if (filenames.hasOwnProperty(i)) {
-					const path = installation.getPathToComponentsFile(module.endpoint.name, filenames[i]);
-					if (yield pfs.exists(path)) {
-						metadata.readme = yield pfs.read(path);
-						break;
-					}
-				}
-			}
+			const readmeFilenames = ['README.md', 'readme.md', 'README', 'readme.txt', 'README.txt'];
+			metadata.readme = yield this._getFileFromList(readmeFilenames, module, installation);
 
 		} catch(e) {
 			// if top-level module is not found that's 404 for the entire API

--- a/lib/utils/string-to-boolean.js
+++ b/lib/utils/string-to-boolean.js
@@ -1,17 +1,17 @@
 'use strict';
 
 const falsyValues = [
-    '0',
-    'false',
-    'no',
-    'none'
+	'0',
+	'false',
+	'no',
+	'none'
 ];
 
 function stringToBoolean(string) {
 	if (falsyValues.indexOf(string.trim()) >= 0) {
-        return false;
-    }
-    return Boolean(string);
+		return false;
+	}
+	return Boolean(string);
 }
 
 module.exports = stringToBoolean;

--- a/test/moduleinstallationtest.js
+++ b/test/moduleinstallationtest.js
@@ -74,7 +74,7 @@ suite('installation-remote', function() {
 
 		const cssStream = yield (new CssBundler({log:log})).getContent(installation, moduleset);
 		const css = yield testhelper.bufferStream(cssStream);
-		assert.include(css, '.o-forms-label');
+		assert.include(css, '.o-forms__label');
 	});
 
 	spawnTestWithTempdir('css-no-minify has_external_dependency', function*(tmpdir) {


### PR DESCRIPTION
Add a new property to the module meta endpoint to return the design guidelines markdown file.

Required for the Registry's new demos construction.