### PR TITLE
Remove o-tweet from examples

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,8 +94,8 @@
 /v2/bundles/js?modules=o-ads@1.2,o-tracking@3,o-cookiewarn@3.3.1
 /v2/bundles/css?modules=o-signinstatus@1.7.3,o-fonts,o-grid@3</code></pre>
 				<p>You should most likely request all the JS modules you want in a single bundle request, and likewise for CSS, and then write them into the <code>&lt;head&gt;</code> or end of the <code>&lt;body&gt;</code> of your HTML document:</p>
-				<pre><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//{{build-service-hostname}}/v2/bundles/css?modules=o-ft-nav@2.3,o-tweet@1,colors&quot; /&gt;
-&lt;script src=&quot;//{{build-service-hostname}}/v2/bundles/js?modules=o-ft-nav@2.3,o-tweet@1,o-tracking@3.5,o-ads@1.2&quot; /&gt;</code></pre>
+				<pre><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//{{build-service-hostname}}/v2/bundles/css?modules=o-ft-nav@2.3,o-share@2,colors&quot; /&gt;
+&lt;script src=&quot;//{{build-service-hostname}}/v2/bundles/js?modules=o-ft-nav@2.3,o-share@2,o-tracking@3.5,o-ads@1.2&quot; /&gt;</code></pre>
 
 				<aside>
 					<h4>Avoiding problems with Content security policy</h4>


### PR DESCRIPTION
Module is being deprecated, should be removed from examples.