### PR TITLE
Ensure that the modules parameter is always a string

### DIFF
--- a/lib/buildsystem.js
+++ b/lib/buildsystem.js
@@ -22,6 +22,9 @@ function getBundleDetails(req) {
 	if (!req.query.modules) {
 		throw new HTTPError(400, 'Missing \'modules\' query argument');
 	}
+	if (typeof req.query.modules !== 'string') {
+		throw new HTTPError(400, 'The \'modules\' query argument must be a comma-separated list of modules');
+	}
 
 	const modules = req.query.modules.split(/\s*,\s*/);
 

--- a/test/integration/v2-bundles-css.js
+++ b/test/integration/v2-bundles-css.js
@@ -112,6 +112,24 @@ describe('GET /v2/bundles/css', function() {
 
 	});
 
+	describe('when the modules parameter is not a string', function() {
+
+		beforeEach(function() {
+			this.request = request(this.app)
+				.get(`/v2/bundles/css?modules[]=foo&modules[]=bar`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function(done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message in a CSS comment', function(done) {
+			this.request.expect('/*\n\nThe \'modules\' query argument must be a comma-separated list of modules\n\n*/\n').end(done);
+		});
+
+	});
+
 	describe('when a module name cannot be parsed', function() {
 		const moduleName = 'http://1.2.3.4/';
 

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -221,6 +221,24 @@ describe('GET /v2/bundles/js', function() {
 
 	});
 
+	describe('when the modules parameter is not a string', function() {
+
+		beforeEach(function() {
+			this.request = request(this.app)
+				.get(`/v2/bundles/js?modules[]=foo&modules[]=bar`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function(done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message in a JavaScript comment', function(done) {
+			this.request.expect('/*\n\nThe \'modules\' query argument must be a comma-separated list of modules\n\n*/\n').end(done);
+		});
+
+	});
+
 	describe('when a module name cannot be parsed', function() {
 		const moduleName = 'http://1.2.3.4/';
 


### PR DESCRIPTION
This fixes [a Sentry error](https://sentry.io/nextftcom/build-service-prod/issues/169351657/) that occurs when someone sets the `modules` query parameter to an array. E.g. `?modules[]=foo&modules[]=bar`.
