### PR TITLE
Add CORS support to enable safer usage when called via JS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ module.exports = function createApp(config) {
 
 	app.disable('x-powered-by');
 
+	app.use(require('cors')());
 	app.use(raven.middleware.express.requestHandler(log.ravenClient));
 
 	if (config.writeAccessLog === true) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bunyan": "^1.5.1",
     "cheerio": "^0.17.0",
     "commander": "^2.3.0",
+    "cors": "^2.8.1",
     "diskspace": "git+http://github.com/Financial-Times/diskspace.js.git",
     "express": "^4.12.3",
     "express-ftwebservice": "^2.0.2",

--- a/test/integration/v2-bundles-css.js
+++ b/test/integration/v2-bundles-css.js
@@ -22,7 +22,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with the bundled CSS', function(done) {
-			this.request.expect(`/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=mock-modules%2Ftest-ok%2Co-autoinit%401.2.0&shrinkwrap=mock-modules%2Ftest-dependency\n */\n#test-ok{hello:world}#test-dependency{dependency:true}`).end(done);
+			this.request.expect(`/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=mock-modules%2Ftest-ok%2Co-autoinit%401.2.1&shrinkwrap=mock-modules%2Ftest-dependency\n */\n#test-ok{hello:world}#test-dependency{dependency:true}`).end(done);
 		});
 
 		it('should minify the bundle', function(done) {

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -22,7 +22,7 @@ describe('GET /v2/bundles/js', function() {
 		});
 
 		it('should respond with the bundled JavaScript', function(done) {
-			this.request.expect(/^\/\*\* Shrinkwrap URL:\n \*      \/v2\/bundles\/js\?modules=mock-modules%2Ftest-ok%2Co-autoinit%401.2.0&shrinkwrap=mock-modules%2Ftest-dependency\n \*\//i).end(done);
+			this.request.expect(/^\/\*\* Shrinkwrap URL:\n \*      \/v2\/bundles\/js\?modules=mock-modules%2Ftest-ok%2Co-autoinit%401\.2\.1&shrinkwrap=mock-modules%2Ftest-dependency\n \*\//i).end(done);
 		});
 
 		it('should minify the bundle', function(done) {


### PR DESCRIPTION
This PR enables requests via JS (I.E. `fetch`) to be able to view if the response was successful or not. This is especially useful in the context of caching responses for use with a serviceworker.