### PR TITLE
Add Ft-Origami-Service-Base-Path header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ We configure Origami Build Service using environment variables. In development, 
   * `METRICS_ENV`: The environment to store metrics under. This defaults to `NODE_ENV`, which allows us to measure QA/production metrics separately.
   * `PREFERRED_HOSTNAME`: The hostname to use in documentation and as a base URL in bundle requests. This defaults to `origami-build.ft.com`.
 
+The service can also be configured by sending HTTP headers, these would normally be set in your CDN config:
+
+  * `FT-Origami-Service-Base-Path`: The base path for the service, this gets prepended to all paths in the HTML and ensures that redirects work when the CDN rewrites URLs.
+
 
 Testing
 -------

--- a/deprecated/v1-deprecated.js
+++ b/deprecated/v1-deprecated.js
@@ -5,7 +5,7 @@ const redirectWithBody = require('../lib/express/redirect-with-body');
 const URL = require('url');
 
 module.exports = function(req, res) {
-	const redirectUrl = '/v2' + URL.parse(req.url).path.replace(/^\/v1/, '');
+	const redirectUrl = req.basePath + 'v2' + URL.parse(req.url).path.replace(new RegExp('^' + req.basePath + 'v1'), '');
 	const redirectBody = 'This endpoint has been removed. You are being redirected to ' + redirectUrl + '\nSee https://' + hostnames.preferred + '/v2/#api-reference for more information.\n';
 	res.type('txt');
 	res.header('Access-Control-Allow-Origin', '*');

--- a/lib/buildsystem.js
+++ b/lib/buildsystem.js
@@ -13,6 +13,7 @@ const HTTPError = require('./express/httperror');
 const CompileError = require('./utils/compileerror');
 const metrics = require('./monitoring/metrics');
 const stringToBoolean = require('./utils/string-to-boolean');
+const path = require('path');
 
 const oneHourMSec = 3600 * 1000;
 const timeoutDurationMSec = 20000;
@@ -239,7 +240,7 @@ function promiseTimeout(duration) {
 
 function selfURL(req) {
 	const qs = Object.keys(req.query).map(function(key) { return key+'='+encodeURIComponent(req.query[key]); });
-	return req.basePath + req.path.replace(/^\//, '') + '?' + qs.join('&');
+	return path.join(req.basePath, req.path) + '?' + qs.join('&');
 }
 
 module.exports = BuildSystem;

--- a/lib/buildsystem.js
+++ b/lib/buildsystem.js
@@ -239,7 +239,7 @@ function promiseTimeout(duration) {
 
 function selfURL(req) {
 	const qs = Object.keys(req.query).map(function(key) { return key+'='+encodeURIComponent(req.query[key]); });
-	return req.path+'?'+qs.join('&');
+	return req.basePath + req.path.replace(/^\//, '') + '?' + qs.join('&');
 }
 
 module.exports = BuildSystem;

--- a/lib/express/get-base-path.js
+++ b/lib/express/get-base-path.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = getBasePath;
+
+function getBasePath(request, response, next) {
+	let basePath = request.headers['ft-origami-service-base-path'] || '/';
+	if (!basePath.startsWith('/')) {
+		basePath = `/${basePath}`;
+	}
+	if (!basePath.endsWith('/')) {
+		basePath = `${basePath}/`;
+	}
+	request.basePath = response.locals.basePath = basePath;
+	next();
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const express = require('express');
 const errorMiddleware = require('./express/errorresponse');
+const getBasePath = require('./express/get-base-path');
 const routes = require('./routes');
 const log = require('./utils/log');
 const morgan = require('morgan');
@@ -19,6 +20,8 @@ module.exports = function createApp(config) {
 		// Add logging to Express
 		app.use(morgan('combined'));
 	}
+
+	app.use(getBasePath);
 
 	routes.bundles(app, config);
 	routes.demos(app, config);

--- a/test/unit/lib/express/get-base-path.js
+++ b/test/unit/lib/express/get-base-path.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+
+describe('lib/express/get-base-path', () => {
+	let express;
+	let getBasePath;
+
+	beforeEach(() => {
+		express = require('../../mock/express.mock');
+		getBasePath = require('../../../../lib/express/get-base-path');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(getBasePath);
+	});
+
+	describe('getBasePath(request, response, next)', () => {
+		let next;
+
+		beforeEach(() => {
+			next = sinon.spy();
+			getBasePath(express.mockRequest, express.mockResponse, next);
+		});
+
+		it('sets `request.basePath` to "/"', () => {
+			assert.strictEqual(express.mockRequest.basePath, '/');
+		});
+
+		it('sets `response.locals.basePath` to "/"', () => {
+			assert.strictEqual(express.mockResponse.locals.basePath, '/');
+		});
+
+		it('calls `next` with no error', () => {
+			assert.calledOnce(next);
+			assert.calledWithExactly(next);
+		});
+
+		describe('when the request has an `FT-Origami-Service-Base-Path` header', () => {
+
+			beforeEach(() => {
+				next.reset();
+				express.mockRequest.headers['ft-origami-service-base-path'] = '/foo/bar/';
+				getBasePath(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('sets `request.basePath` to the header value', () => {
+				assert.strictEqual(express.mockRequest.basePath, '/foo/bar/');
+			});
+
+			it('sets `response.locals.basePath` to the header value', () => {
+				assert.strictEqual(express.mockResponse.locals.basePath, '/foo/bar/');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+		});
+
+		describe('when the `FT-Origami-Service-Base-Path` header does not begin or end with a slash', () => {
+
+			beforeEach(() => {
+				next.reset();
+				express.mockRequest.headers['ft-origami-service-base-path'] = 'foo/bar';
+				getBasePath(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('sets `request.basePath` to the header value with slashes added', () => {
+				assert.strictEqual(express.mockRequest.basePath, '/foo/bar/');
+			});
+
+			it('sets `response.locals.basePath` to the header value with slashes added', () => {
+				assert.strictEqual(express.mockResponse.locals.basePath, '/foo/bar/');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/express/redirect-with-body.test.js
+++ b/test/unit/lib/express/redirect-with-body.test.js
@@ -16,32 +16,30 @@ describe('lib/express/redirect-with-body', function() {
 	});
 
 	describe('redirectWithBody(response, status, location, body)', function() {
-		let response;
 		let status;
 		let location;
 		let body;
 
 		beforeEach(function() {
-			response = express.createMockResponse();
 			status = 301;
 			location = 'foo';
 			body = 'bar';
-			redirectWithBody(response, status, location, body);
+			redirectWithBody(express.mockResponse, status, location, body);
 		});
 
 		it('should set the response status', function() {
-			assert.calledOnce(response.status);
-			assert.calledWithExactly(response.status, status);
+			assert.calledOnce(express.mockResponse.status);
+			assert.calledWithExactly(express.mockResponse.status, status);
 		});
 
 		it('should set the response location', function() {
-			assert.calledOnce(response.location);
-			assert.calledWithExactly(response.location, location);
+			assert.calledOnce(express.mockResponse.location);
+			assert.calledWithExactly(express.mockResponse.location, location);
 		});
 
 		it('should send the response body', function() {
-			assert.calledOnce(response.send);
-			assert.calledWithExactly(response.send, body);
+			assert.calledOnce(express.mockResponse.send);
+			assert.calledWithExactly(express.mockResponse.send, body);
 		});
 
 	});

--- a/test/unit/lib/index.test.js
+++ b/test/unit/lib/index.test.js
@@ -2,10 +2,12 @@
 
 const assert = require('chai').assert;
 const mockery = require('mockery');
+const sinon = require('sinon');
 
 describe('lib/index', function() {
 	let errorResponse;
 	let express;
+	let getBasePath;
 	let index;
 	let log;
 	let morgan;
@@ -19,6 +21,9 @@ describe('lib/index', function() {
 
 		express = require('../mock/express.mock');
 		mockery.registerMock('express', express);
+
+		getBasePath = sinon.spy();
+		mockery.registerMock('./express/get-base-path', getBasePath);
 
 		routes = require('../mock/routes.mock');
 		mockery.registerMock('./routes', routes);
@@ -71,6 +76,10 @@ describe('lib/index', function() {
 
 		it('should not create a morgan logger', function() {
 			assert.notCalled(morgan);
+		});
+
+		it('should register the get-base-path middleware', function() {
+			assert.calledWithExactly(expressApp.use, getBasePath);
 		});
 
 		it('should register the bundles route', function() {

--- a/test/unit/mock/express.mock.js
+++ b/test/unit/mock/express.mock.js
@@ -7,13 +7,18 @@ module.exports = sinon.stub().returns({
 	use: sinon.spy()
 });
 
-module.exports.createMockResponse = function() {
-	const response = {
-		location: sinon.stub(),
-		send: sinon.stub(),
-		status: sinon.stub()
-	};
-	response.location.returns(response);
-	response.status.returns(response);
-	return response;
+module.exports.mockRequest = {
+	headers: {},
+	query: {},
+	params: {}
+};
+
+module.exports.mockResponse = {
+	locals: {},
+	location: sinon.stub(),
+	redirect: sinon.stub().returnsThis(),
+	render: sinon.stub().returnsThis(),
+	send: sinon.stub().returnsThis(),
+	set: sinon.stub().returnsThis(),
+	status: sinon.stub().returnsThis()
 };


### PR DESCRIPTION
CDNs can now send an FT-Origami-Service-Base-Path header to change the
base path across the site documentation. This ensures that when the CDN
performs rewrites, they don't break. It also allows us to access the
service from either ft.com/__origami/... or the heroku URLs without
having to mount routes twice.