### PR TITLE
increase first-byte-timeout to a minute

### DIFF
--- a/cdn/backends/backends.json
+++ b/cdn/backends/backends.json
@@ -4,7 +4,7 @@
 		"connect_timeout": 3000,
 		"port": 443,
 		"hostname": "origami-build-service-eu.herokuapp.com",
-		"first_byte_timeout": 15000,
+		"first_byte_timeout": 60000,
 		"max_conn": 200,
 		"between_bytes_timeout": 10000,
 		"healthcheck": "Heroku GTG",


### PR DESCRIPTION
This is fixing the symptom, the root issue is the fact we are buffering our response instead of streaming it. Not sure if that is possible for build service but we can give it a go.