### PR TITLE
Only alert when the CPU hits 125%

### DIFF
--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -76,10 +76,10 @@ function healthChecks(options) {
 			// It will fail if usage is above the threshold
 			{
 				type: 'cpu',
-				threshold: 75,
+				threshold: 125,
 				interval: 15000,
 				id: 'system-load',
-				name: 'System CPU usage is below 75%',
+				name: 'System CPU usage is below 125%',
 				severity: 1,
 				businessImpact: 'Application may not be able to serve all requests',
 				technicalSummary: 'Process is hitting the CPU harder than expected',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@financial-times/health-check": "^1.0.1",
+    "@financial-times/health-check": "^1.1.0",
     "@financial-times/origami-service": "^2.0.2",
     "blocked": "^1.1.0",
     "bower": "1.3.12",


### PR DESCRIPTION
The service regularly hits 100-115% and is fine. I've increased the
alert threshold to stop flip-flopping of healthchecks.