### PR TITLE
use version of obt which uses raw-loader for txt files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mime": "^1.2.11",
     "mkdirp": "^0.5.1",
     "morgan": "^1.6.1",
-    "origami-build-tools": "^5.6.3",
+    "origami-build-tools": "^5.6.4",
     "q": "^1.0.1",
     "q-io": "^1.12.0",
     "request": "^2.79.0",


### PR DESCRIPTION
The new version of o-comments uses txt files instead of html files. 