### PR TITLE
Switch to the new Bower registry

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const options = {
 	log: console,
 	metricsAppName: 'origami-build-service',
 	name: 'Origami Build Service',
-	registryURL: process.env.REGISTRY_URL || 'http://registry.origami.ft.com',
+	registryURL: process.env.REGISTRY_URL || 'http://origami-bower-registry.ft.com',
 	tempdir: `/tmp/buildservice-${process.pid}/`,
 	testHealthcheckFailure: process.env.TEST_HEALTHCHECK_FAILURE || false
 };

--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -47,15 +47,15 @@ function healthChecks(options) {
 			// bad response or socket timeout
 			{
 				type: 'tcp-ip',
-				host: 'registry.origami.ft.com',
+				host: 'origami-bower-registry.ft.com',
 				port: 80,
 				interval: 10 * 60 * 1000, // 10 minutes
 				id: 'registry-tcp-port-80',
-				name: 'Availability of registry.origami.ft.com (TCP/IP connectivity to registry.origami.ft.com on port 80)',
+				name: 'Availability of origami-bower-registry.ft.com (TCP/IP connectivity to origami-bower-registry.ft.com on port 80)',
 				severity: 2,
 				technicalSummary: 'This will prevent any new modules from installing and being built.  If this continues to fail for large periods of time, expect end user reports from critical sites if left unfixed.',
 				businessImpact: 'As problem persists, more and more Origami components in use on live sites may appear broken, unstyled or absent. This may not start to happen for several hours because the service retains saved copies of existing files for some time.',
-				panicGuide: 'Check whether `registry.origami.ft.com` loads in a web browser. If not, refer to http://registry.origami.ft.com/__health for more information.'
+				panicGuide: 'Check whether `origami-bower-registry.ft.com` loads in a web browser. If not, refer to http://origami-bower-registry.ft.com/__health for more information.'
 			},
 
 			// This check monitors the process memory usage

--- a/lib/moduleinstallation.js
+++ b/lib/moduleinstallation.js
@@ -5,7 +5,6 @@ const EndpointParser = require('bower-endpoint-parser');
 const Q = require('./utils/q');
 const pfs = require('q-io/fs');
 const URL = require('url');
-const os = require('os');
 const path = require('path');
 const glob = Q.denodeify(require('glob'));
 const rmrf = Q.denodeify(require('rimraf'));
@@ -487,36 +486,6 @@ ModuleInstallation.prototype = {
 		}
 		return err;
 	}
-};
-
-ModuleInstallation.addHealthChecks = function(healthMonitor, registry, tempdir) {
-	const businessImpact = 'As problem persists, more and more Origami components in use on live sites may appear broken, unstyled or absent. This may not start to happen for several hours because the service retains saved copies of existing files for some time.';
-
-	healthMonitor.addTcpIpCheck({
-		name: 'Availability of the Origami Registry (TCP/IP to registry.origami.ft.com)',
-		severity: 2,
-		technicalSummary: 'This may prevent new Origami CSS/JS bundles from being created and the service will start failing within 24h as caches expire',
-		businessImpact: businessImpact,
-		panicGuide: 'Ensure HTTP requests to registry.origami.ft.com work from ' + os.hostname() + '.  Try: loading http://registry.origami.ft.com in a web browser, if that fails there is an issue with http://registry.origami.ft.com, refer to registry.origami.ft.com\'s run book.  If loading in a browser succeeds try: `ssh ' + os.hostname() + '`, then `nc -w 5 -z registry.origami.ft.com 80`.  If the output of the `nc` command is successful it will output something like: `Connection to registry.origami.ft.com port 80 [tcp/*] succeeded!`, if `nc` is unsuccessful the output will be blank after approximately 5 seconds. Escalate to the Networks team if `nc` is unsuccessful otherwise check registry.origami.ft.com\'s runbook.',
-		checkPeriod: 30,
-	}, 'registry.origami.ft.com', 80);
-
-	healthMonitor.addDiskChecks({
-		technicalSummary: 'Temp directory is full, so no new components can be installed',
-		severity: 1,
-		businessImpact: businessImpact,
-		panicGuide: 'Safely clean temp on ' + os.hostname() + ' and restart (this won\'t affect cached bundles, only files served from the /files/ endpoint):\n\n sudo service buildservice stop\n { for i in /tmp/buildservice-*; do sudo mv "$i" /tmp/deleteme; sudo rm -rf /tmp/deleteme; done } &\n sudo service buildservice restart',
-		checkPeriod: 10,
-	}, tempdir);
-
-	healthMonitor.addMemoryChecks({
-		technicalSummary: 'Process ran out of memory',
-		severity: 1,
-		businessImpact: businessImpact,
-		panicGuide: 'Restart the service on ' + os.hostname() + ', Try: `ssh ' + os.hostname() + '`, then `sudo service buildservice restart` and re-check health status for http://' + os.hostname() + ':8080/__health',
-		checkPeriod: 11,
-	});
-
 };
 
 module.exports = ModuleInstallation;

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -4,7 +4,7 @@ const requestPromise = require('./utils/request-promise');
 
 class Registry {
 	constructor({
-		registryURL = 'http://registry.origami.ft.com'
+		registryURL = 'http://origami-bower-registry.ft.com'
 	} = {}) {
 		this.registryURL = registryURL;
 	}

--- a/n.Makefile
+++ b/n.Makefile
@@ -17,7 +17,7 @@ SHELL := /bin/bash
 # Some handy utilities
 GLOB = git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
 NPM_INSTALL = npm prune --production=false && npm install
-BOWER_INSTALL = bower prune && bower install --config.registry.search=http://registry.origami.ft.com --config.registry.search=https://bower.herokuapp.com
+BOWER_INSTALL = bower prune && bower install --config.registry.search=http://origami-bower-registry.ft.com --config.registry.search=https://bower.herokuapp.com
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
 VERSION = v1.4.33

--- a/test/unit/lib/registry.test.js
+++ b/test/unit/lib/registry.test.js
@@ -22,9 +22,9 @@ describe('lib/registry', () => {
 
 	describe('Registry(options)', () => {
 
-		it('defaults the registryURL to http://registry.origami.ft.com', () => {
+		it('defaults the registryURL to http://origami-bower-registry.ft.com', () => {
 			const registry = new Registry();
-			assert.equal(registry.registryURL, 'http://registry.origami.ft.com');
+			assert.equal(registry.registryURL, 'http://origami-bower-registry.ft.com');
 		});
 
 		it('can specify the registryURL', () => {


### PR DESCRIPTION
This switches the Build Service to use the new Bower registry. I've
tested locally and everything seems fine, suggest getting it on QA and
maybe running some more extensive tests before we hit production.

This also removes some old health checks which weren't used anywhere. We
must have missed them on an earlier refactor, I removed them as they
referenced the old registry.