### PR TITLE
Correct the markdown mimetype in the tests

### DIFF
--- a/test/integration/v2-files.js
+++ b/test/integration/v2-files.js
@@ -21,7 +21,7 @@ describe('GET /v2/files', function() {
 		});
 
 		it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/x-markdown').end(done);
+			this.request.expect('Content-Type', 'text/markdown').end(done);
 		});
 
 		it('should respond with the file contents', function(done) {


### PR DESCRIPTION
It's now valid and matches what the `mime` module returns. See https://tools.ietf.org/html/rfc7763