### PR TITLE
Allow only valid bower names to be used via our HTTP API

### DIFF
--- a/lib/middleware/cleanModulesParameter.js
+++ b/lib/middleware/cleanModulesParameter.js
@@ -20,7 +20,7 @@ module.exports = function () {
 			*/
 			const moduleVersionPairs = request.query.modules.split(',').map(module => module.split('@'));
 
-			const invalidModuleVersionPairs = moduleVersionPairs.filter(function ([name, version = '']) {
+			const invalidModuleVersionPairs = moduleVersionPairs.filter(function ([name]) {
 				return !isValidBowerModuleName(name);
 			});
 

--- a/lib/middleware/cleanModulesParameter.js
+++ b/lib/middleware/cleanModulesParameter.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = function () {
+
+	/**
+	 * Middleware used to enforce all modules names in the modules query parameter conform to the bower.json specification.
+	 * https://github.com/bower/spec/blob/master/json.md#name
+	 *
+	 * If all modules names are valid according to bower, move on to the next middleware.
+	 * If any modules names are not valid, return an HTTP 400 status code, specifying which module names are invalid.
+	 */
+	return (request, response, next) => {
+		if (request.query.modules) {
+
+			/*
+				Turns 'o-colors,o-grid@^4,o-techdocs@*,o-buttons@latest'
+				into [['o-colors', ''], ['o-grid', '^4'], ['o-techdocs', '*'], ['o-buttons', 'latest']]
+			*/
+			const moduleVersionPairs = request.query.modules.split(',').map(module => module.split('@'));
+
+			const invalidModuleVersionPairs = moduleVersionPairs.filter(function ([name, version = '']) {
+				return !isValidBowerModuleName(name);
+			});
+
+			if (invalidModuleVersionPairs.length > 0) {
+				const invalidModuleVersionsString = invalidModuleVersionPairs.map(([name]) => name).join(', ');
+
+				next(
+					httpError(400, `The modules parameter contains module names which are not valid: ${invalidModuleVersionsString}`)
+				);
+
+			} else {
+				next();
+			}
+		} else {
+			next();
+		}
+	};
+};
+
+/**
+ * Checks a Bower module name conforms to the bower.json specification.
+ * @param {String} name A Bower module name.
+ * @returns {Boolean} Whether the name parameter is valid according to bower.
+ */
+function isValidBowerModuleName(name = '') {
+	return /^[a-z0-9_][a-z0-9_\.\-]*[a-z0-9_]$/.test(name.toLowerCase());
+}

--- a/lib/routes/v2/bundles.js
+++ b/lib/routes/v2/bundles.js
@@ -2,11 +2,13 @@
 
 const outputBundle = require('../../middleware/outputBundle');
 const requireModulesParameter = require('../../middleware/requireModulesParameter');
+const cleanModulesParameter = require('../../middleware/cleanModulesParameter');
 
 module.exports = app => {
 	app.get(
 		/^\/v2\/bundles\/(css|js)/,
 		requireModulesParameter(),
+		cleanModulesParameter(),
 		outputBundle(app)
 	);
 };

--- a/test/integration/v2-bundles-css.js
+++ b/test/integration/v2-bundles-css.js
@@ -145,7 +145,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with an error message ', function(done) {
-			this.request.expect(/unable to parse module name/i).end(done);
+			this.request.expect(/The modules parameter contains module names which are not valid: http:\/\/1.2.3.4\//i).end(done);
 		});
 
 	});
@@ -165,5 +165,25 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 	});
+
+});
+
+describe('when a module name is a relative directory', function() {
+		const moduleName = '../../../example';
+
+		beforeEach(function() {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/css?modules=${moduleName}&newerthan=${now}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function(done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message ', function(done) {
+			this.request.expect(/The modules parameter contains module names which are not valid: \.\.\/\.\.\/\.\.\/example/i).end(done);
+		});
 
 });

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -257,7 +257,7 @@ describe('GET /v2/bundles/js', function() {
 		});
 
 		it('should respond with an error message', function(done) {
-			this.request.expect(/unable to parse module name/i).end(done);
+			this.request.expect(/The modules parameter contains module names which are not valid: http:\/\/1.2.3.4\//i).end(done);
 		});
 
 	});
@@ -277,5 +277,25 @@ describe('GET /v2/bundles/js', function() {
 		});
 
 	});
+
+});
+
+describe('when a module name is a relative directory', function() {
+		const moduleName = '../../../example';
+
+		beforeEach(function() {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function(done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message ', function(done) {
+			this.request.expect(/The modules parameter contains module names which are not valid: \.\.\/\.\.\/\.\.\/example/i).end(done);
+		});
 
 });

--- a/test/unit/lib/middleware/cleanModulesParameter.js
+++ b/test/unit/lib/middleware/cleanModulesParameter.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+describe('lib/middleware/cleanModulesParameter', () => {
+	let httpError;
+	let origamiService;
+	let cleanModulesParameter;
+
+	beforeEach(() => {
+		origamiService = require('../../mock/origami-service.mock');
+
+		httpError = require('../../mock/http-errors.mock');
+		mockery.registerMock('http-errors', httpError);
+
+		cleanModulesParameter = require('../../../../lib/middleware/cleanModulesParameter');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(cleanModulesParameter);
+	});
+
+	describe('cleanModulesParameter()', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = cleanModulesParameter();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				next = sinon.spy();
+				origamiService.mockRequest.query.modules = 'valid1,Valid2@^3.0.1,-invalid1,valid3@~2.x,invalid2.@*,../../../../test';
+				middleware(origamiService.mockRequest, origamiService.mockResponse, next);
+			});
+
+			// it('calls `next` with error', () => {
+			// 	assert.calledOnce(next);
+			// 	assert.calledWithExactly(next);
+			// });
+
+			// it('removes invalid modules from request.query.modules', () => {
+			// 	assert.strictEqual(origamiService.mockRequest.query.modules, 'valid1,Valid2@^3.0.1,valid3@~2.x');
+			// });
+
+			it('creates a 400 HTTP error with a descriptive message', () => {
+				assert.calledOnce(httpError);
+				assert.calledWithExactly(httpError, 400, 'The modules parameter contains module names which are not valid: -invalid1, invalid2., ../../../../test');
+			});
+
+			it('calls `next` with the created error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next, httpError.mockError);
+			});
+
+			describe('when the `modules` query parameter is missing', () => {
+
+				beforeEach(() => {
+					next.reset();
+					httpError.reset();
+					delete origamiService.mockRequest.query.modules;
+					middleware(origamiService.mockRequest, origamiService.mockResponse, next);
+				});
+
+				it('calls `next`', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+				it('does not modify request.query.modules', () => {
+					assert.isUndefined(origamiService.mockRequest.query.modules);
+				});
+			});
+
+			describe('when the `modules` query parameter is an empty string', () => {
+
+				beforeEach(() => {
+					next.reset();
+					httpError.reset();
+					origamiService.mockRequest.query.modules = '';
+					middleware(origamiService.mockRequest, origamiService.mockResponse, next);
+				});
+
+				it('calls `next`', () => {
+					assert.calledOnce(next);
+					assert.calledWithExactly(next);
+				});
+
+				it('does not modify request.query.modules', () => {
+					assert.strictEqual(origamiService.mockRequest.query.modules, '');
+				});
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/middleware/cleanModulesParameter.js
+++ b/test/unit/lib/middleware/cleanModulesParameter.js
@@ -42,15 +42,6 @@ describe('lib/middleware/cleanModulesParameter', () => {
 				middleware(origamiService.mockRequest, origamiService.mockResponse, next);
 			});
 
-			// it('calls `next` with error', () => {
-			// 	assert.calledOnce(next);
-			// 	assert.calledWithExactly(next);
-			// });
-
-			// it('removes invalid modules from request.query.modules', () => {
-			// 	assert.strictEqual(origamiService.mockRequest.query.modules, 'valid1,Valid2@^3.0.1,valid3@~2.x');
-			// });
-
 			it('creates a 400 HTTP error with a descriptive message', () => {
 				assert.calledOnce(httpError);
 				assert.calledWithExactly(httpError, 400, 'The modules parameter contains module names which are not valid: -invalid1, invalid2., ../../../../test');


### PR DESCRIPTION
This stops relative paths from being used in ?modules=... as well as any other format which is not valid according to the bower.json name specification.

https://github.com/bower/spec/blob/master/json.md#name

If a module name in the modules query parameter is not valid, we return an HTTP 400 status code telling the user that the module name(s) is invalid.