### PR TITLE
Execute JS bundles in js build tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,18 @@
         "through2": "2.0.3"
       }
     },
+    "@types/node": {
+      "version": "8.0.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.49.tgz",
+      "integrity": "sha512-Oq3cV/mrMKy6Tv42llfS8YIH30ooDdhbJ40h1zoWl+goOJw8Kjy8j8RfjGZtZIUDO0gLwCfcbYM7+LModnbeMw==",
+      "dev": true
+    },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -85,6 +97,23 @@
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+    },
+    "acorn-globals": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.2.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "dev": true
+        }
+      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -305,6 +334,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "array-filter": {
       "version": "0.0.1",
@@ -2151,6 +2186,12 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
@@ -2295,6 +2336,12 @@
         }
       }
     },
+    "cssom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "dev": true
+    },
     "CSSselect": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
@@ -2302,6 +2349,15 @@
       "requires": {
         "CSSwhat": "0.4.7",
         "domutils": "1.4.3"
+      }
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.2"
       }
     },
     "CSSwhat": {
@@ -2684,6 +2740,12 @@
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
+    "domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
+      "dev": true
+    },
     "domhandler": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
@@ -2792,6 +2854,29 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "editorconfig": {
+      "version": "github:editorconfig/editorconfig-core-js#50e0dba81b2f7f3e9ea4f701f2c65dd3f482cd4c",
+      "requires": {
+        "commander": "1.1.1",
+        "lru-cache": "2.0.4",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+          "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
+          "requires": {
+            "keypress": "0.1.0"
+          }
+        },
+        "lru-cache": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.0.4.tgz",
+          "integrity": "sha1-uLYa4JhIOF7Gdodg45wSPn45Voo="
+        }
       }
     },
     "ee-first": {
@@ -6096,7 +6181,11 @@
         "isomorphic-fetch": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-1.7.0.tgz",
-          "integrity": "sha1-FePrh8L7RAEpumtLjc+DvjDlBiA="
+          "integrity": "sha1-FePrh8L7RAEpumtLjc+DvjDlBiA=",
+          "requires": {
+            "whatwg-fetch": "github:matthew-andrews/fetch#8ebf5cbbc1e8496bf5dc4c48fd38af349106787d",
+            "xmlhttprequest": "github:matthew-andrews/node-XMLHttpRequest#79a415ca98d689651e4a9f6a1ec0fe71d416b120"
+          }
         },
         "minimist": {
           "version": "1.2.0",
@@ -6224,6 +6313,15 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.3"
+      }
     },
     "htmlparser2": {
       "version": "3.7.3",
@@ -6989,6 +7087,44 @@
       "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
       "dev": true
     },
+    "jsdom": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.3.0.tgz",
+      "integrity": "sha512-aPZTDl4MplzQhx5bLztk6nzjbEslmO3Q3+z0WpCMutL1XJDhZIRzir6R1Y8S84LgeT/7jhQvgtUMkY6oPwvlUw==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "5.2.1",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.2",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "domexception": "1.0.0",
+        "escodegen": "1.9.0",
+        "html-encoding-sniffer": "1.0.2",
+        "nwmatcher": "1.4.3",
+        "parse5": "3.0.3",
+        "pn": "1.0.0",
+        "request": "2.83.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-url": "6.3.0",
+        "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
@@ -7071,6 +7207,11 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -7191,6 +7332,7 @@
       "resolved": "https://registry.npmjs.org/lintspaces/-/lintspaces-0.3.3.tgz",
       "integrity": "sha1-Z0l5AWaaPRga9hVEnaT/UF4KqaI=",
       "requires": {
+        "editorconfig": "github:editorconfig/editorconfig-core-js#50e0dba81b2f7f3e9ea4f701f2c65dd3f482cd4c",
         "merge": "1.1.2"
       }
     },
@@ -7568,6 +7710,12 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "lodash.template": {
       "version": "3.6.2",
@@ -8811,6 +8959,12 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "nwmatcher": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -9370,6 +9524,15 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.49"
+      }
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -9674,6 +9837,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+    },
+    "pn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
+      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.13",
@@ -11329,6 +11498,12 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
       "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
     },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
     "sync-exec": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
@@ -11760,6 +11935,23 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
         "punycode": "1.4.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
       }
     },
     "traverse": {
@@ -12268,6 +12460,12 @@
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
       "integrity": "sha1-tm5Wqd8L0lp2u/G1FNsSkIBhSjc="
     },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "webpack": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
@@ -12402,6 +12600,29 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
       "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0="
     },
+    "whatwg-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "github:matthew-andrews/fetch#8ebf5cbbc1e8496bf5dc4c48fd38af349106787d"
+    },
+    "whatwg-url": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.3.0.tgz",
+      "integrity": "sha512-rM+hE5iYKGPAOu05mIdJR47pYSR2vDzfrTEFRc/S8D3L60yW8BuXmUJ7Kog7x/DrokFN7JNaHKadpzjouKRRAw==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "which": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
@@ -12529,6 +12750,12 @@
         "user-home": "1.1.1"
       }
     },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
+    },
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
@@ -12542,6 +12769,9 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "xmlhttprequest": {
+      "version": "github:matthew-andrews/node-XMLHttpRequest#79a415ca98d689651e4a9f6a1ec0fe71d416b120"
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "dotenv": "^2.0.0",
     "eslint": "^4.8.0",
     "istanbul": "^0.4.5",
+    "jsdom": "^11.3.0",
     "lintspaces-cli": "^0.1.1",
     "mocha": "^2.4.5",
     "mockery": "^1.4.0",

--- a/test/integration/v2-bundles-js.js
+++ b/test/integration/v2-bundles-js.js
@@ -5,418 +5,426 @@ const request = require('supertest');
 const jsdom = require('jsdom');
 const sinon = require('sinon');
 
+const CORE_JS_GLOBAL_PROPERTY = '__core-js_shared__';
+
 const { JSDOM } = jsdom;
 
-const createWindow = () => new JSDOM(``, {
-	runScripts: 'dangerously'
+const createWindow = () => new JSDOM('', {
+    runScripts: 'dangerously'
 }).window;
 
 const executeScript = (script, givenWindow) => {
-	let internalWindowError;
+    let internalWindowError;
     const window = typeof givenWindow !== 'undefined' ? givenWindow : createWindow();
 
     const scriptEl = window.document.createElement('script');
     scriptEl.textContent = script;
-	window.onerror = error => {
-		internalWindowError = error;
-		throw error;
+    window.onerror = error => {
+        internalWindowError = error;
+        throw error;
+    };
+    window.document.body.appendChild(scriptEl);
+    if (internalWindowError) {
+        throw internalWindowError;
     }
-	window.document.body.appendChild(scriptEl);
-	if (internalWindowError) {
-		throw internalWindowError;
-	}
-	return window;
-}
+    return window;
+};
 
 describe('GET /v2/bundles/js', function() {
-	this.timeout(20000);
-	this.slow(5000);
+    this.timeout(20000);
+    this.slow(5000);
 
-	describe('when a valid module is requested', function() {
-		const moduleName = 'o-test-component@1.0.2';
+    describe('when a valid module is requested', function() {
+        const moduleName = 'o-test-component@1.0.2';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should respond with the bundled JavaScript', function(done) {
-			this.request
+        it('should respond with the bundled JavaScript', function(done) {
+            this.request
                 .expect(/^\/\*\* Shrinkwrap URL:\n \*/)
                 .expect(({ text }) => {
                     assert.doesNotThrow(() => executeScript(text));
                 })
                 .end(done);
-		});
+        });
 
-		it('should minify the bundle', function(done) {
-			this.request.end((error, response) => {
-				assert.notInclude(response.text, '// unminified');
-				done(error);
-			});
-		});
+        it('should minify the bundle', function(done) {
+            this.request.end((error, response) => {
+                assert.notInclude(response.text, '// unminified');
+                done(error);
+            });
+        });
 
-		it('should export the bundle under `window.Origami`', function(done) {
-			this.request
-				.expect(({text}) => {
-					let resultWindow;
-					assert.doesNotThrow(() => {
-						resultWindow = executeScript(text);
-					});
-					assert.property(resultWindow, 'Origami');
-					assert.property(resultWindow.Origami, moduleName.split('@')[0]);
-				})
-				.end(done);
-		});
+        it('should export the bundle under `window.Origami`', function(done) {
+            this.request
+                .expect(({text}) => {
+                    let resultWindow;
+                    assert.doesNotThrow(() => {
+                        resultWindow = executeScript(text);
+                    });
+                    assert.property(resultWindow, 'Origami');
+                    assert.property(resultWindow.Origami, moduleName.split('@')[0]);
+                })
+                .end(done);
+        });
 
-	});
+    });
 
-	describe('when a valid module is requested (with the `minify` parameter set to `none`)', function() {
-		const moduleName = 'o-test-component@1.0.2';
+    describe('when a valid module is requested (with the `minify` parameter set to `none`)', function() {
+        const moduleName = 'o-test-component@1.0.2';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&minify=none`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&minify=none`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should respond with the bundled JavaScript unminified', function(done) {
-			this.request.expect(/ sourceMappingURL=data:application\/json;charset=utf-8;base64,/i).end(done);
-		});
+        it('should respond with the bundled JavaScript unminified', function(done) {
+            this.request.expect(/ sourceMappingURL=data:application\/json;charset=utf-8;base64,/i).end(done);
+        });
 
-	});
+    });
 
-	describe('when a valid module is requested (with the `autoinit` parameter set to `0`)', function() {
-		const moduleName = 'o-test-component@1.0.2';
+    describe('when a valid module is requested (with the `autoinit` parameter set to `0`)', function() {
+        const moduleName = 'o-test-component@1.0.2';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&autoinit=0`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&autoinit=0`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should respond with the bundled JavaScript without the o-autoinit module', function(done) {
-			this.request
-				.expect(({ text }) => {
-					let resultWindow;
-					assert.doesNotThrow(() => {
-						resultWindow = executeScript(text);
-					});
-					assert.property(resultWindow, 'Origami');
-					assert.notProperty(resultWindow.Origami, 'o-autoinit')
-				})
-				.end(done);
-		});
+        it('should respond with the bundled JavaScript without the o-autoinit module', function(done) {
+            this.request
+                .expect(({ text }) => {
+                    let resultWindow;
+                    assert.doesNotThrow(() => {
+                        resultWindow = executeScript(text);
+                    });
+                    assert.property(resultWindow, 'Origami');
+                    assert.notProperty(resultWindow.Origami, 'o-autoinit');
+                })
+                .end(done);
+        });
 
-	});
+    });
 
-	describe('when a valid module is requested (with the `export` parameter set to `foo`)', function() {
-		const moduleName = 'o-test-component@1.0.2';
+    describe('when a valid module is requested (with the `export` parameter set to `foo`)', function() {
+        const moduleName = 'o-test-component@1.0.2';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&export=foo`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&export=foo`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should export the bundle under `window.foo`', function(done) {
-			this.request
-				.expect(({ text }) => {
-					let resultWindow;
-					assert.doesNotThrow(() => {
-						resultWindow = executeScript(text);
-					});
-					assert.property(resultWindow, 'foo');
-					assert.property(resultWindow.foo, moduleName.split('@')[0]);
-				})
-				.end(done);
-		});
+        it('should export the bundle under `window.foo`', function(done) {
+            this.request
+                .expect(({ text }) => {
+                    let resultWindow;
+                    assert.doesNotThrow(() => {
+                        resultWindow = executeScript(text);
+                    });
+                    assert.property(resultWindow, 'foo');
+                    assert.property(resultWindow.foo, moduleName.split('@')[0]);
+                })
+                .end(done);
+        });
 
-	});
+    });
 
-	describe('when a valid module is requested (with the `export` parameter set to an empty string)', function() {
-		const moduleName = 'o-test-component@1.0.2';
+    describe('when a valid module is requested (with the `export` parameter set to an empty string)', function() {
+        const moduleName = 'o-test-component@1.0.2';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&export=`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&export=`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should not export the bundle onto `window`', function(done) {
-			let givenWindow = createWindow()
-			Object.defineProperty(givenWindow, 'Origami', { set() {
-				throw new Error('Attempted to set Origami property on window')
-			} });
-			this.request
-				.expect(({ text }) => {
-					assert.doesNotThrow(() => executeScript(text, givenWindow))
-					assert.notProperty(givenWindow, 'Origimi');
-				})
-				.end(done);
-		});
+        it('should not export the bundle onto `window`', function(done) {
+            const givenWindow = createWindow();
+            Object.defineProperty(givenWindow, 'Origami', { set() {
+                throw new Error('Attempted to set Origami property on window');
+            } });
+            this.request
+                .expect(({ text }) => {
+                    assert.doesNotThrow(() => executeScript(text, givenWindow));
+                    assert.notProperty(givenWindow, 'Origimi');
+                })
+                .end(done);
+        });
 
-	});
+    });
 
-	describe('when a valid module is requested (with the `callback` parameter set to a non-empty string)', function() {
-		const moduleName = 'o-test-component@1.0.2';
-		const givenCallback = 'page.load.deep';
+    describe('when a valid module is requested (with the `callback` parameter set to a non-empty string)', function() {
+        const moduleName = 'o-test-component@1.0.2';
+        const givenCallback = 'page.load.deep';
 
-		const makeRequest = function(callback) {
-			const now = new Date().toISOString();
-			return request(this.app)
+        const makeRequest = function(callback) {
+            const now = new Date().toISOString();
+            return request(this.app)
                 .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&callback=${callback}`)
                 .set('Connection', 'close');
-		};
+        };
 
         it('should respond with a 200 status', function(done) {
             makeRequest.call(this, givenCallback)
                 .expect(200)
                 .end(done);
-		});
+        });
 
-		it('should include the given callback parameter, executed with the bundle context', function(done) {
-			let givenWindow = createWindow()
-			givenWindow.page = {
-				load: {
-					deep: sinon.stub()
-				}
-			}
-			makeRequest.call(this, givenCallback)
-				.expect(({text}) => {
-					assert.doesNotThrow(() => executeScript(text, givenWindow))
-					assert.property(givenWindow.page.load.deep.getCall(0).args[0], moduleName.split('@')[0])
-				})
-				.end(done);
-		});
+        it('should include the given callback parameter, executed with the bundle context', function(done) {
+            const givenWindow = createWindow();
+            givenWindow.page = {
+                load: {
+                    deep: sinon.stub()
+                }
+            };
+            makeRequest.call(this, givenCallback)
+                .expect(({text}) => {
+                    assert.doesNotThrow(() => executeScript(text, givenWindow));
+                    assert.property(givenWindow.page.load.deep.getCall(0).args[0], moduleName.split('@')[0]);
+                })
+                .end(done);
+        });
 
-		[';my.Function', 'my.function;other'].forEach((callback) => {
-			it(`should call the callback if it is '${callback}' and does not match the pattern ^[\\w\\.]+$`, function(done) {
-				let givenWindow = createWindow()
-				givenWindow.page = {
-					load: {
-						deep: sinon.stub()
-					}
-				}
-				makeRequest.call(this, callback)
+        [';my.Function', 'my.function;other'].forEach((callback) => {
+            it(`should call the callback if it is '${callback}' and does not match the pattern ^[\\w\\.]+$`, function(done) {
+                const givenWindow = createWindow();
+                givenWindow.page = {
+                    load: {
+                        deep: sinon.stub()
+                    }
+                };
+                makeRequest.call(this, callback)
                     .expect(({text}) => {
-						assert.doesNotThrow(() => executeScript(text, givenWindow))
-						assert.isTrue(givenWindow.page.load.deep.notCalled, 'Callback was called unexpectedly')
+                        assert.doesNotThrow(() => executeScript(text, givenWindow));
+                        assert.isTrue(givenWindow.page.load.deep.notCalled, 'Callback was called unexpectedly');
                     })
                     .end(done);
-			});
-		});
+            });
+        });
     });
 
-	describe('when a valid module is requested (with the `polyfills` parameter set to `none`)', function() {
-		const moduleName = 'o-test-component@1.0.2';
+    describe('when a valid module is requested (with the `polyfills` parameter set to `none`)', function() {
+        const moduleName = 'o-test-component@1.0.2';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&polyfills=none&minify=none`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&polyfills=none&minify=none`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should respond with the bundled JavaScript with no polyfills', function(done) {
-			this.request
-				.expect(({ text }) => {
-					assert.doesNotThrow(() => executeScript(text))
-					assert.notMatch(text, /Array\.from/) // Fragile check which depends on core-js source code
-				})
-				.end(done);
-		});
+        it('should respond with the bundled JavaScript with no polyfills', function(done) {
+            this.request
+                .expect(({ text }) => {
+                    let resultWindow;
+                    assert.doesNotThrow(() => {
+                        resultWindow = executeScript(text);
+                    });
+                    assert.notProperty(resultWindow, CORE_JS_GLOBAL_PROPERTY);
+                })
+                .end(done);
+        });
 
-	});
+    });
 
-	describe('when a valid module is requested (with the `polyfills` parameter set to `true`)', function() {
-		/**
-		 * We need to request a module which uses features which will trigger Babel to include the polyfill set.
-		 */
-		const moduleName = 'o-test-component@1.0.16';
+    describe('when a valid module is requested (with the `polyfills` parameter set to `true`)', function() {
+        /**
+         * We need to request a module which uses features which will trigger Babel to include the polyfill set.
+         */
+        const moduleName = 'o-test-component@1.0.16';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&polyfills=true&minify=none`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}&polyfills=true&minify=none`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
+        it('should respond with a 200 status', function(done) {
+            this.request.expect(200).end(done);
+        });
 
-		it('should respond with the bundled JavaScript containing polyfills', function(done) {
-			this.request
-				.expect(({ text }) => {
-					assert.doesNotThrow(() => executeScript(text))
-					assert.notMatch(text, /Array\.isArray/) // Fragile check which depends on core-js source code
-				})
-				.end(done);
-		});
+        it('should respond with the bundled JavaScript containing polyfills', function(done) {
+            this.request
+                .expect(({ text }) => {
+                    let resultWindow;
+                    assert.doesNotThrow(() => {
+                        resultWindow = executeScript(text);
+                    });
+                    assert.property(resultWindow, CORE_JS_GLOBAL_PROPERTY);
+                })
+                .end(done);
+        });
 
-	});
+    });
 
-	describe('when an invalid module is requested (nonexistent)', function() {
-		const moduleName = 'test-404';
+    describe('when an invalid module is requested (nonexistent)', function() {
+        const moduleName = 'test-404';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 404 status', function(done) {
-			this.request.expect(404).end(done);
-		});
+        it('should respond with a 404 status', function(done) {
+            this.request.expect(404).end(done);
+        });
 
-		it('should respond with an error message', function(done) {
-			this.request.expect(/package .* not found/i).end(done);
-		});
+        it('should respond with an error message', function(done) {
+            this.request.expect(/package .* not found/i).end(done);
+        });
 
-	});
+    });
 
-	describe('when an invalid module is requested (JavaScript compilation error)', function() {
-		const moduleName = 'o-test-component@1.0.1';
+    describe('when an invalid module is requested (JavaScript compilation error)', function() {
+        const moduleName = 'o-test-component@1.0.1';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 560 status', function(done) {
-			this.request.expect(560).end(done);
-		});
+        it('should respond with a 560 status', function(done) {
+            this.request.expect(560).end(done);
+        });
 
-		it('should respond with an error message', function(done) {
-			this.request.expect(/cannot complete build due to compilation error from build tools:/i).end(done);
-		});
+        it('should respond with an error message', function(done) {
+            this.request.expect(/cannot complete build due to compilation error from build tools:/i).end(done);
+        });
 
-	});
+    });
 
-	describe('when the modules parameter is missing', function() {
+    describe('when the modules parameter is missing', function() {
 
-		beforeEach(function() {
-			this.request = request(this.app)
-				.get('/v2/bundles/js')
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            this.request = request(this.app)
+                .get('/v2/bundles/js')
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 400 status', function(done) {
-			this.request.expect(400).end(done);
-		});
+        it('should respond with a 400 status', function(done) {
+            this.request.expect(400).end(done);
+        });
 
-		it('should respond with an error message', function(done) {
-			this.request.expect(/the modules parameter is required and must be a comma-separated list of modules/i).end(done);
-		});
+        it('should respond with an error message', function(done) {
+            this.request.expect(/the modules parameter is required and must be a comma-separated list of modules/i).end(done);
+        });
 
-	});
+    });
 
-	describe('when the modules parameter is not a string', function() {
+    describe('when the modules parameter is not a string', function() {
 
-		beforeEach(function() {
-			this.request = request(this.app)
-				.get('/v2/bundles/js?modules[]=foo&modules[]=bar')
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            this.request = request(this.app)
+                .get('/v2/bundles/js?modules[]=foo&modules[]=bar')
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 400 status', function(done) {
-			this.request.expect(400).end(done);
-		});
+        it('should respond with a 400 status', function(done) {
+            this.request.expect(400).end(done);
+        });
 
-		it('should respond with an error message', function(done) {
-			this.request.expect(/the modules parameter is required and must be a comma-separated list of modules/i).end(done);
-		});
+        it('should respond with an error message', function(done) {
+            this.request.expect(/the modules parameter is required and must be a comma-separated list of modules/i).end(done);
+        });
 
-	});
+    });
 
-	describe('when a module name cannot be parsed', function() {
-		const moduleName = 'http://1.2.3.4/';
+    describe('when a module name cannot be parsed', function() {
+        const moduleName = 'http://1.2.3.4/';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 400 status', function(done) {
-			this.request.expect(400).end(done);
-		});
+        it('should respond with a 400 status', function(done) {
+            this.request.expect(400).end(done);
+        });
 
-		it('should respond with an error message', function(done) {
-			this.request.expect(/The modules parameter contains module names which are not valid: http:\/\/1.2.3.4\//i).end(done);
-		});
+        it('should respond with an error message', function(done) {
+            this.request.expect(/The modules parameter contains module names which are not valid: http:\/\/1.2.3.4\//i).end(done);
+        });
 
-	});
+    });
 
-	describe('when the bundle type is invalid', function() {
-		const moduleName = 'o-test-component@1.0.11';
+    describe('when the bundle type is invalid', function() {
+        const moduleName = 'o-test-component@1.0.11';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/javascript?modules=${moduleName}&newerthan=${now}`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/javascript?modules=${moduleName}&newerthan=${now}`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 404 status', function(done) {
-			this.request.expect(404).end(done);
-		});
+        it('should respond with a 404 status', function(done) {
+            this.request.expect(404).end(done);
+        });
 
-	});
+    });
 
 });
 
 describe('when a module name is a relative directory', function() {
-		const moduleName = '../../../example';
+        const moduleName = '../../../example';
 
-		beforeEach(function() {
-			const now = (new Date()).toISOString();
-			this.request = request(this.app)
-				.get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
-				.set('Connection', 'close');
-		});
+        beforeEach(function() {
+            const now = (new Date()).toISOString();
+            this.request = request(this.app)
+                .get(`/v2/bundles/js?modules=${moduleName}&newerthan=${now}`)
+                .set('Connection', 'close');
+        });
 
-		it('should respond with a 400 status', function(done) {
-			this.request.expect(400).end(done);
-		});
+        it('should respond with a 400 status', function(done) {
+            this.request.expect(400).end(done);
+        });
 
-		it('should respond with an error message ', function(done) {
-			this.request.expect(/The modules parameter contains module names which are not valid: \.\.\/\.\.\/\.\.\/example/i).end(done);
-		});
+        it('should respond with an error message ', function(done) {
+            this.request.expect(/The modules parameter contains module names which are not valid: \.\.\/\.\.\/\.\.\/example/i).end(done);
+        });
 
 });


### PR DESCRIPTION
Previously these tests used fragile string comparisons.

Updated to execute the webpack bundle using [jsdom](https://github.com/tmpvar/jsdom) and check the side-effects on the window.

This does not improve the state of polyfill tests as any checks on these still require knowledge of the polyfill tests or core-js internals.