### PR TITLE
Add surrogate cache control header with 1 year TTL to deprecated routes

### DIFF
--- a/deprecated/v1-deprecated-bundle.js
+++ b/deprecated/v1-deprecated-bundle.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const {getStaticBundleStream} = require('./static-bundle');
+const handleDeprecatedRoute = require('./v1-deprecated');
+
+module.exports = function handleDeprecatedBundle(req, res) {
+    const { metrics } = req.app.origami;
+    // If we have a static cached version of the route, serve it.
+    // Otherwise we redirect to a non-deprecated route.
+    getStaticBundleStream(
+        req.url,
+        req.app.origami.options.staticBundlesDirectory
+    )
+        .then(bundleStream => {
+            metrics.count('routes.bundle.deprecated.serve', 1);
+            res.type(req.params[0]);
+            bundleStream.pipe(res);
+        })
+        .catch(() => {
+            req.url = req.url.replace(`${req.basePath}v1/`, req.basePath);
+            handleDeprecatedRoute(req, res);
+            metrics.count('routes.bundle.deprecated.redirect', 1);
+        });
+};

--- a/deprecated/v1-deprecated.js
+++ b/deprecated/v1-deprecated.js
@@ -4,11 +4,14 @@ const hostnames = require('../lib/utils/hostnames');
 const redirectWithBody = require('../lib/express/redirect-with-body');
 const URL = require('url');
 
+const ONE_YEAR_SECONDS = 31536000;
+
 module.exports = function(req, res) {
 	const requestPath = URL.parse(req.url).path;
 	const redirectUrl = requestPath.replace(new RegExp('^/(v1/)?'), req.basePath + 'v2/');
 	const redirectBody = 'This endpoint has been removed. You are being redirected to ' + redirectUrl + '\nSee https://' + hostnames.preferred + '/v2/#api-reference for more information.\n';
 	res.type('txt');
 	res.header('Access-Control-Allow-Origin', '*');
+	res.header('Surrogate-Control', `public, max-age=${ONE_YEAR_SECONDS}, stale-while-revalidate=${ONE_YEAR_SECONDS}, stale-if-error=${ONE_YEAR_SECONDS}`);
 	redirectWithBody(res, 301, redirectUrl, redirectBody);
 };

--- a/lib/routes/bundles.js
+++ b/lib/routes/bundles.js
@@ -1,25 +1,7 @@
 'use strict';
 
-const getStaticBundleStream = require('../../deprecated/static-bundle').getStaticBundleStream;
-const handleDeprecatedRoute = require('../../deprecated/v1-deprecated');
+const handleDeprecatedBundle = require('../../deprecated/v1-deprecated-bundle');
 
 module.exports = function(app) {
-
-	app.get(/^\/bundles\/(css|js)/, handleDeprecatedBundle);
-
-	function handleDeprecatedBundle(req, res) {
-		const {metrics} = req.app.origami;
-		// If we have a static cached version of the route, serve it.
-		// Otherwise we redirect to a non-deprecated route.
-		getStaticBundleStream(req.url, app.origami.options.staticBundlesDirectory)
-			.then((bundleStream) => {
-				metrics.count('routes.bundle.deprecated.serve', 1);
-				res.type(req.params[0]);
-				bundleStream.pipe(res);
-			})
-			.catch(() => {
-				handleDeprecatedRoute(req, res);
-				metrics.count('routes.bundle.deprecated.redirect', 1);
-			});
-	}
+    app.get(/^\/bundles\/(css|js)/, handleDeprecatedBundle);
 };

--- a/lib/routes/v1/bundles.js
+++ b/lib/routes/v1/bundles.js
@@ -1,26 +1,7 @@
 'use strict';
 
-const getStaticBundleStream = require('../../../deprecated/static-bundle').getStaticBundleStream;
-const handleDeprecatedRoute = require('../../../deprecated/v1-deprecated');
+const handleDeprecatedBundle = require('../../../deprecated/v1-deprecated-bundle');
 
 module.exports = function(app) {
-
 	app.get(/^\/v1\/bundles\/(css|js)/, handleDeprecatedBundle);
-
-	function handleDeprecatedBundle(req, res) {
-		const {metrics} = req.app.origami;
-		// If we have a static cached version of the route, serve it.
-		// Otherwise we redirect to a non-deprecated route.
-		getStaticBundleStream(req.url, app.origami.options.staticBundlesDirectory)
-			.then((bundleStream) => {
-				metrics.count('routes.bundle.deprecated.serve', 1);
-				res.type(req.params[0]);
-				bundleStream.pipe(res);
-			})
-			.catch(() => {
-				req.url = req.url.replace(`${req.basePath}v1/`, req.basePath);
-				handleDeprecatedRoute(req, res);
-				metrics.count('routes.bundle.deprecated.redirect', 1);
-			});
-	}
 };

--- a/lib/routes/v1/index.js
+++ b/lib/routes/v1/index.js
@@ -1,9 +1,12 @@
 'use strict';
 
+const ONE_YEAR_SECONDS = 31536000;
+
 module.exports = app => {
 
 	// v1 endpoint redirect
 	app.get('/v1', (request, response) => {
+		response.header('Surrogate-Control', `public, max-age=${ONE_YEAR_SECONDS}, stale-while-revalidate=${ONE_YEAR_SECONDS}, stale-if-error=${ONE_YEAR_SECONDS}`);
 		response.redirect(301, `${request.basePath}v2/`);
 	});
 

--- a/test/integration/v1-bundles-css.js
+++ b/test/integration/v1-bundles-css.js
@@ -20,6 +20,12 @@ describe('GET /v1/bundles/css', function() {
 			this.request.expect(301).end(done);
 		});
 
+		it('should response with a year long surrogate cache control header', function(done) {
+			this.request
+				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+				.end(done);
+		});
+
 		it('should respond with a v2 `Location` header', function(done) {
 			this.request.expect('Location', `/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
 		});

--- a/test/integration/v1-bundles-js.js
+++ b/test/integration/v1-bundles-js.js
@@ -20,6 +20,13 @@ describe('GET /v1/bundles/js', function() {
 			this.request.expect(301).end(done);
 		});
 
+		it('should response with a year long surrogate cache control header', function(done) {
+			this.request
+				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+				.end(done);
+
+		});
+
 		it('should respond with a v2 `Location` header', function(done) {
 			this.request.expect('Location', `/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
 		});

--- a/test/integration/v1-files.js
+++ b/test/integration/v1-files.js
@@ -20,6 +20,12 @@ describe('GET /v1/files', function() {
 			this.request.expect(301).end(done);
 		});
 
+		it('should response with a year long surrogate cache control header', function(done) {
+			this.request
+				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+				.end(done);
+		});
+
 		it('should respond with a v2 `Location` header', function(done) {
 			this.request.expect('Location', `/v2/files/${moduleName}/${pathName}`).end(done);
 		});

--- a/test/integration/v1-modules.js
+++ b/test/integration/v1-modules.js
@@ -19,6 +19,12 @@ describe('GET /v1/modules', function() {
 			this.request.expect(301).end(done);
 		});
 
+		it('should response with a year long surrogate cache control header', function(done) {
+			this.request
+				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+				.end(done);
+		});
+
 		it('should respond with a v2 `Location` header', function(done) {
 			this.request.expect('Location', `/v2/modules/${moduleName}`).end(done);
 		});

--- a/test/integration/v1.js
+++ b/test/integration/v1.js
@@ -16,6 +16,12 @@ describe('GET /v1', function() {
 		this.request.expect(301).end(done);
 	});
 
+	it('should response with a year long surrogate cache control header', function(done) {
+		this.request
+			.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+			.end(done);
+	});
+
 	it('should respond with HTML', function(done) {
 		this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
 	});


### PR DESCRIPTION
This affects 301 redirect responses only, not cached responses which seem to be catered for.

Closes https://github.com/Financial-Times/origami-build-service/issues/117.