### PR TITLE
README fixes: Circle CI master badge and match node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Origami Build Service
 
 See [the production service][production-url] for API information.
 
-[![Build status](https://img.shields.io/circleci/project/Financial-Times/origami-build-service.svg)][ci]
+[![Build status](https://img.shields.io/circleci/project/Financial-Times/origami-build-service/master.svg)][ci]
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)][license]
 
 
@@ -30,7 +30,7 @@ Table Of Contents
 Requirements
 ------------
 
-Running Origami Build Service requires [Node.js] 4.x and [npm].
+Running Origami Build Service requires [Node.js] 8.x and [npm].
 
 
 Running Locally


### PR DESCRIPTION
The CircleCI badge was pointing to any branch so broken PRs influenced it. Changed to master.
The node version didn't match that in package.json/engines.node (8.6) or CI.