### PR TITLE
Prevent race condition when building branded CSS.

### DIFF
--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -91,7 +91,7 @@ CssBundler.prototype = {
 	 */
 	getContent: Q.async(function* (installation, moduleset, brand, options) {
 		const opts = options || {};
-		const relativeMainSassPath = 'main-' + moduleset.getMainPathOverridesIdentifier() + '.scss';
+		const relativeMainSassPath = 'main-' + moduleset.getMainPathOverridesIdentifier() + '-' + brand + '.scss';
 		const mainSassPath = path.join(installation.getDirectory(), relativeMainSassPath);
 
 		const buildOutputPath = installation.getDirectory();

--- a/test/integration/v2-bundles-css.test.js
+++ b/test/integration/v2-bundles-css.test.js
@@ -49,7 +49,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with the bundled CSS unminified', function(done) {
-			this.request.expect('/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.4%2Co-autoinit%401.5.0&shrinkwrap=\n */\n#test-compile-error {\n  color: red; }\n\n/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJvd2VyX2NvbXBvbmVudHMvby10ZXN0LWNvbXBvbmVudC9tYWluLnNjc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ0E7RUFDQyxXQUFVLEVBQ1YiLCJmaWxlIjoibWFpbi07LmNzcyIsInNvdXJjZXNDb250ZW50IjpbIlxuI3Rlc3QtY29tcGlsZS1lcnJvciB7XG5cdGNvbG9yOiByZWQ7XG59XG4iXX0= */\n').end(done);
+			this.request.expect('/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.4%2Co-autoinit%401.5.0&shrinkwrap=\n */\n#test-compile-error {\n  color: red; }\n\n/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJvd2VyX2NvbXBvbmVudHMvby10ZXN0LWNvbXBvbmVudC9tYWluLnNjc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ0E7RUFDQyxXQUFVLEVBQ1YiLCJmaWxlIjoibWFpbi07LW1hc3Rlci5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJcbiN0ZXN0LWNvbXBpbGUtZXJyb3Ige1xuXHRjb2xvcjogcmVkO1xufVxuIl19 */\n').end(done);
 		});
 
 	});

--- a/test/integration/v2-bundles-css.test.js
+++ b/test/integration/v2-bundles-css.test.js
@@ -22,7 +22,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with the bundled CSS', function(done) {
-			this.request.expect('/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.4%2Co-autoinit%401.3.3&shrinkwrap=\n */\n#test-compile-error{color:red}').end(done);
+			this.request.expect('/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.4%2Co-autoinit%401.5.0&shrinkwrap=\n */\n#test-compile-error{color:red}').end(done);
 		});
 
 		it('should minify the bundle', function(done) {
@@ -49,7 +49,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with the bundled CSS unminified', function(done) {
-			this.request.expect('/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.4%2Co-autoinit%401.3.3&shrinkwrap=\n */\n#test-compile-error {\n  color: red; }\n\n/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJvd2VyX2NvbXBvbmVudHMvby10ZXN0LWNvbXBvbmVudC9tYWluLnNjc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ0E7RUFDQyxXQUFVLEVBQ1YiLCJmaWxlIjoibWFpbi07LmNzcyIsInNvdXJjZXNDb250ZW50IjpbIlxuI3Rlc3QtY29tcGlsZS1lcnJvciB7XG5cdGNvbG9yOiByZWQ7XG59XG4iXX0= */\n').end(done);
+			this.request.expect('/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.4%2Co-autoinit%401.5.0&shrinkwrap=\n */\n#test-compile-error {\n  color: red; }\n\n/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJvd2VyX2NvbXBvbmVudHMvby10ZXN0LWNvbXBvbmVudC9tYWluLnNjc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ0E7RUFDQyxXQUFVLEVBQ1YiLCJmaWxlIjoibWFpbi07LmNzcyIsInNvdXJjZXNDb250ZW50IjpbIlxuI3Rlc3QtY29tcGlsZS1lcnJvciB7XG5cdGNvbG9yOiByZWQ7XG59XG4iXX0= */\n').end(done);
 		});
 
 	});


### PR DESCRIPTION
If two CSS bundles are building at the same time, and they are identical except for the brand, there is a race condition which means the same bundle will be returned for both. The impact is that the built CSS for one of the requests is for the incorrect brand.

This happens because the build service writes a Sass file to build which includes the brand Sass variable. The Sass filename was unique for each module set, but not for each module set and brand.

Before. With two build requests, one for the internal and another for the master brand, the same Sass file is created (and overridden):
<img width="881" alt="Screenshot 2019-03-12 at 15 31 35" src="https://user-images.githubusercontent.com/10405691/54213661-a9932f00-44dc-11e9-898a-fae3e4775a00.png">

Before. Separate Sass files are created per brand:
<img width="972" alt="Screenshot 2019-03-12 at 15 30 21" src="https://user-images.githubusercontent.com/10405691/54213733-cdef0b80-44dc-11e9-97cd-27d6864d18fc.png">
