### PR TITLE
Error when building a component for an unsupported brand.

### DIFF
--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -8,7 +8,6 @@ const toShrinkwrapUrl = require('./shrinkwrap').toUrl;
 const CompileError = require('./utils/compileerror');
 const streamCat = require('streamcat');
 const hostnames = require('./utils/hostnames');
-const raven = require('raven');
 
 const gulp = require('gulp');
 const obt = require('origami-build-tools');
@@ -209,19 +208,10 @@ CssBundler.prototype = {
 					const manifest = yield installation.getOrigamiManifest(name);
 					const isOrigami = Boolean(manifest);
 					const supportsBrand = manifest && (!manifest.brands || manifest.brands.includes(brand));
-
-					// TODO - Introduce an error if Raven does not capture anything.
 					if (isOrigami && !supportsBrand) {
 						const brands = manifest && manifest.brands ? manifest.brands : [];
 						const msg = name + ' does not support the ' + brand + ' brand. Please set a supported brand ' + (brands.length > 1 ? '(one of: ' + brands.join(', ') + ') ' : '') + (brands.length === 1 ? '(' + brands[0] + ') ' : '') + 'using the "brand" query parameter, otherwise contact the Origami team to propose adding ' + brand + ' brand support to ' + name + '.';
-						raven.captureException(new Error(msg), {
-							extra: {
-								brand,
-								name,
-								version: allComponents[name].version,
-							},
-							level: 'warning'
-						});
+						throw new CompileError(msg);
 					}
 				}
 

--- a/test/integration/v2-bundles-css.test.js
+++ b/test/integration/v2-bundles-css.test.js
@@ -3,7 +3,7 @@
 const assert = require('chai').assert;
 const request = require('supertest');
 
-describe('GET /v2/bundles/css', function() {
+describe.only('GET /v2/bundles/css', function() {
 	this.timeout(20000);
 	this.slow(5000);
 
@@ -92,6 +92,43 @@ describe('GET /v2/bundles/css', function() {
 			this.request.expect(/cannot complete build due to compilation error from build tools:/i).end(done);
 		});
 
+	});
+
+	describe('when a branded module is requested for a brand it does not support', function() {
+		const moduleName = 'o-layout@3.0.0';
+		const brand = 'master';
+
+		beforeEach(function() {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/css?modules=${moduleName}&newerthan=${now}&brand=${brand}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 560 status', function(done) {
+			this.request.expect(560).end(done);
+		});
+
+		it('should respond with an error message ', function(done) {
+			this.request.expect(/o-layout does not support the master brand/i).end(done);
+		});
+
+	});
+
+	describe('when a branded module is requested for a supported brand', function() {
+		const moduleName = 'o-layout@3.0.0';
+		const brand = 'internal';
+
+		beforeEach(function() {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/css?modules=${moduleName}&newerthan=${now}&brand=${brand}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function(done) {
+			this.request.expect(200).end(done);
+		});
 	});
 
 	describe('when the modules parameter is missing', function() {

--- a/test/integration/v2-bundles-css.test.js
+++ b/test/integration/v2-bundles-css.test.js
@@ -3,7 +3,7 @@
 const assert = require('chai').assert;
 const request = require('supertest');
 
-describe.only('GET /v2/bundles/css', function() {
+describe('GET /v2/bundles/css', function() {
 	this.timeout(20000);
 	this.slow(5000);
 


### PR DESCRIPTION
This is more helpful than broken CSS or a general Sass build failure.

Relates to: https://github.com/Financial-Times/origami-build-service/pull/188