### PR TITLE
 Add source query parameter.

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -19,11 +19,8 @@ function Bundler(options) {
 Bundler.prototype = {
 	/** Given a requested ModuleSet, and its installation return an Output
 	 */
-	getBundle: Q.async(function* (type, installationPromise, moduleSet, brand, options) {
+	getBundle: Q.async(function* (type, installationPromise, moduleSet, options) {
 		const opts = options || {};
-		if (brand) {
-			opts.brand = brand;
-		}
 		const log = this.log;
 		const metrics = this.metrics;
 
@@ -32,7 +29,8 @@ Bundler.prototype = {
 
 		const uniqueIdentifier =
 			modules.getIdentifier() +
-			(type === 'css' && brand ? brand : '') + // Only CSS changes according to the brand.
+			(type === 'css' && options.brand ? options.brand + '.'  : '') + // Only CSS changes according to the brand.
+			(type === 'css' && options.source ? options.source + '.'  : '') + // Only CSS changes according to the source.
 			moduleSet.getMainPathOverridesIdentifier() + '.' +
 			(opts.demoName ? opts.demoName + '.' : '') +
 			type + '.' +
@@ -50,7 +48,7 @@ Bundler.prototype = {
 				timeToLive: installation.getTTL() - 500,
 				newerThan: options.newerThan,
 				createCallback: Q.async(function*(){
-					const contentStream = this._createContentStream(type, installationPromise, moduleSet, brand, options);
+					const contentStream = this._createContentStream(type, installationPromise, moduleSet, options);
 					log.info({id: uniqueIdentifier}, 'Creating new bundle');
 					return {
 						result: new Output(this._getMimeType(type), yield Q.streamIntoBuffer(contentStream), installation.getTTL())
@@ -64,10 +62,7 @@ Bundler.prototype = {
 		;
 	}),
 
-	_createContentStream: function (type, installationPromise, moduleSet, brand, options) {
-		if (brand) {
-			options.brand = brand;
-		}
+	_createContentStream: function (type, installationPromise, moduleSet, options) {
 		const metrics = this.metrics;
 		let bundler;
 
@@ -84,7 +79,7 @@ Bundler.prototype = {
 		const bundleStreamPromise = installationPromise.then(function(installation) {
 			const buildStartTime = Date.now();
 			return bundler
-				.getContent(installation, moduleSet, brand, options)
+				.getContent(installation, moduleSet, options)
 				.then(function(bundle) {
 					const buildEndTime = Date.now();
 					metrics.count('bundles.buildTime', buildEndTime - buildStartTime);

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -29,8 +29,8 @@ Bundler.prototype = {
 
 		const uniqueIdentifier =
 			modules.getIdentifier() +
-			(type === 'css' && options.brand ? options.brand + '.'  : '') + // Only CSS changes according to the brand.
-			(type === 'css' && options.source ? options.source + '.'  : '') + // Only CSS changes according to the source.
+			(type === 'css' && options.brand ? options.brand + '.' : '') + // Only CSS changes according to the brand.
+			(type === 'css' && options.source ? options.source + '.' : '') + // Only CSS changes according to the source.
 			moduleSet.getMainPathOverridesIdentifier() + '.' +
 			(opts.demoName ? opts.demoName + '.' : '') +
 			type + '.' +

--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -46,7 +46,7 @@ CssBundler.prototype = {
 		});
 	},
 
-	createMainFile: Q.async(function* (installation, moduleset, brand, mainScriptPath, options) {
+	createMainFile: Q.async(function* (installation, moduleset, mainScriptPath, options) {
 		if (!installation || !installation.getBowerComponentsDir) throw new Error('Needs installation');
 
 		const opts = options || {};
@@ -60,7 +60,7 @@ CssBundler.prototype = {
 		const allComponents = yield installation.listAll();
 		const requestedComponents = yield installation.getInstalledInModuleset(moduleset);
 
-		const mainSassDescription = yield this._compileSassFiles(installation, requestedComponents, allComponents, brand, opts);
+		const mainSassDescription = yield this._compileSassFiles(installation, requestedComponents, allComponents, opts);
 
 		const sassVariables = [];
 		for (const name in mainSassDescription.variables) {
@@ -88,15 +88,15 @@ CssBundler.prototype = {
 	 *
 	 * options.minify === "none" disables minification (on by default).
 	 */
-	getContent: Q.async(function* (installation, moduleset, brand, options) {
+	getContent: Q.async(function* (installation, moduleset, options) {
 		const opts = options || {};
-		const relativeMainSassPath = 'main-' + moduleset.getMainPathOverridesIdentifier() + '-' + brand + '.scss';
+		const relativeMainSassPath = 'main-' + moduleset.getMainPathOverridesIdentifier() + '-' + opts.brand + '.scss';
 		const mainSassPath = path.join(installation.getDirectory(), relativeMainSassPath);
 
 		const buildOutputPath = installation.getDirectory();
-		const buildOutputName = 'build-' + moduleset.getMainPathOverridesIdentifier() + '-' + brand + '.js';
+		const buildOutputName = 'build-' + moduleset.getMainPathOverridesIdentifier() + '-' + opts.brand + '.js';
 
-		const mainFilePromise = this.createMainFile(installation, moduleset, brand, mainSassPath, opts);
+		const mainFilePromise = this.createMainFile(installation, moduleset, mainSassPath, opts);
 		const shrinkwrapPromise = this.createShrinkWrapComment(installation, moduleset, opts);
 		const bundlePromise = this._doBuild(installation, mainFilePromise, path.join(buildOutputPath, '/build'), buildOutputName, opts);
 
@@ -174,11 +174,15 @@ CssBundler.prototype = {
 		return readpromises;
 	},
 
-	_compileSassFiles: Q.async(function* (installation, requestedComponents, allComponents, brand) {
+	_compileSassFiles: Q.async(function* (installation, requestedComponents, allComponents, options) {
 		const variables = {};
 
-		if (brand) {
-			variables['o-brand'] = brand;
+		if (options.brand) {
+			variables['o-brand'] = options.brand;
+		}
+
+		if (options.source) {
+			variables['system-code'] = options.source;
 		}
 
 		const imports = [];
@@ -207,10 +211,10 @@ CssBundler.prototype = {
 				if (isRequested && !oLayoutBrandException) {
 					const manifest = yield installation.getOrigamiManifest(name);
 					const isOrigami = Boolean(manifest);
-					const supportsBrand = manifest && (!manifest.brands || manifest.brands.includes(brand));
+					const supportsBrand = manifest && (!manifest.brands || manifest.brands.includes(options.brand));
 					if (isOrigami && !supportsBrand) {
 						const brands = manifest && manifest.brands ? manifest.brands : [];
-						const msg = name + ' does not support the ' + brand + ' brand. Please set a supported brand ' + (brands.length > 1 ? '(one of: ' + brands.join(', ') + ') ' : '') + (brands.length === 1 ? '(' + brands[0] + ') ' : '') + 'using the "brand" query parameter, otherwise contact the Origami team to propose adding ' + brand + ' brand support to ' + name + '.';
+						const msg = name + ' does not support the ' + options.brand + ' brand. Please set a supported brand ' + (brands.length > 1 ? '(one of: ' + brands.join(', ') + ') ' : '') + (brands.length === 1 ? '(' + brands[0] + ') ' : '') + 'using the "brand" query parameter, otherwise contact the Origami team to propose adding ' + options.brand + ' brand support to ' + name + '.';
 						throw new CompileError(msg);
 					}
 				}

--- a/lib/democompiler.js
+++ b/lib/democompiler.js
@@ -54,7 +54,7 @@ DemoCompiler.prototype = {
 				dist: true,
 				demoFilter: options.demoName,
 				cwd: installation.getComponentDir(options.moduleName),
-				brand: options. brand
+				brand: options.brand
 			};
 
 			log.trace(demoConfig, 'Starting OBT Demo build');

--- a/lib/democompiler.js
+++ b/lib/democompiler.js
@@ -17,7 +17,7 @@ function DemoCompiler(options) {
 
 DemoCompiler.prototype = {
 
-	getContent: Q.async(function* (installation, moduleset, brand, options) {
+	getContent: Q.async(function* (installation, moduleset, options) {
 		const installedModules = yield installation.list(moduleset);
 		options.moduleName = Object.keys(installedModules)[0];
 		options.moduleVersion = installedModules[options.moduleName].version;
@@ -34,7 +34,7 @@ DemoCompiler.prototype = {
 			const versionLockedContent = new Buffer(this.fileProxy.versionLockBuildserviceUrls(yield pfs.readFile(demoAbsolutePath, 'utf8'), options.moduleName, options.moduleVersion, 'https://' + hostnames.preferred + options.reqUrl));
 			return versionLockedContent;
 		} else {
-			const demoBuildPromise = this._doBuild(installation, moduleset, brand, options);
+			const demoBuildPromise = this._doBuild(installation, moduleset, options);
 			// Concatenate buffers and streams in order asynchronously, returns a
 			// ReadStream with the concatenated content
 			return streamCat([
@@ -47,14 +47,14 @@ DemoCompiler.prototype = {
 		}
 	}),
 
-	_doBuild: function (installation, moduleset, brand, options) {
+	_doBuild: function (installation, moduleset, options) {
 		return new Promise((resolve, reject) => {
 			const log = this.log;
 			const demoConfig = {
 				dist: true,
 				demoFilter: options.demoName,
 				cwd: installation.getComponentDir(options.moduleName),
-				brand: brand
+				brand: options. brand
 			};
 
 			log.trace(demoConfig, 'Starting OBT Demo build');

--- a/lib/jsbundler.js
+++ b/lib/jsbundler.js
@@ -100,11 +100,8 @@ JsBundler.prototype = {
 	 *
 	 * @return Promise
 	 */
-	getContent: Q.async(function* (installation, moduleset, brand, options) {
+	getContent: Q.async(function* (installation, moduleset, options) {
 		const opts = options || {};
-		if (brand) {
-			opts.brand = brand;
-		}
 
 		const uniqueIdentifier =
 			moduleset.getIdentifier() +

--- a/lib/middleware/cleanBrandParameter.js
+++ b/lib/middleware/cleanBrandParameter.js
@@ -14,6 +14,11 @@ module.exports = function () {
                 httpError(400, `The brand parameter must be one of: ${acceptedBrands.join(', ')}.`)
             );
         } else {
+            // Fallback for the brand query parameter until v3 requires it:
+            // https://github.com/Financial-Times/origami-build-service/issues/199
+            if (!brand) {
+                request.query.brand = 'master';
+            }
             next();
         }
     };

--- a/lib/middleware/cleanSourceParameter.js
+++ b/lib/middleware/cleanSourceParameter.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = function () {
+	/**
+	 * Middleware used to enforce the source parameter matches v1.3 of the system code spec.
+     * We currently check that the source is a valid system code, not that it exists.
+     * @see https://docs.google.com/document/d/1RCwmr7J98oEi1ELoKMLsbZslvPe4VZ6eY_ZLQ4c8Yqc
+	 */
+    return (request, response, next) => {
+        const source = request.query.source;
+        if (source && !(typeof source === 'string' && source.match(/^[a-z0-9\-]{3,32}$/))) {
+            next(
+                httpError(400, 'The "source" parameter must be a valid system code, according to v1.3 of the system code spec.')
+            );
+        } else {
+            // Fallback for the source query parameter until v3 requires it:
+            // https://github.com/Financial-Times/origami-build-service/issues/67
+            if (!source) {
+                request.query.source = 'build-service';
+            }
+            next();
+        }
+    };
+};

--- a/lib/middleware/outputBundle.js
+++ b/lib/middleware/outputBundle.js
@@ -31,12 +31,17 @@ module.exports = app => {
 			modules.push('o-autoinit@^1.0.0');
 		}
 
+		const source = req.query['source'];
+		const brand = req.query['brand'];
+
 		return {
 			babelRuntime: req.query.polyfills ? stringToBoolean(req.query.polyfills) : true,
 			callback: (req.query['callback'] && /^[\w\.]+$/.test(req.query['callback'])) ? req.query['callback'] : undefined,
 			exportName: (req.query['export'] === undefined) ? 'Origami' : req.query['export'],
 			minify: !(req.query.minify && req.query.minify === 'none'),
 			modules: new ModuleSet(modules),
+			source: source,
+			brand: brand,
 			newerThan: req.query.newerthan ? Date.parse(req.query.newerthan) : false,
 			versionLocks: req.query.shrinkwrap ? new ModuleSet(req.query.shrinkwrap.split(/\s*,\s*/)) : false
 		};
@@ -50,7 +55,6 @@ module.exports = app => {
 
 	return function outputBundle(req, res, next) {
 		const type = req.params[0];
-		const brand = req.query['brand'] || 'master';
 		const bundleDetails = getBundleDetails(req);
 		const moduleset = bundleDetails.modules;
 		const moduleInstallationPromise = installationManager.createInstallation(moduleset, bundleDetails);
@@ -59,7 +63,7 @@ module.exports = app => {
 		// Also when running multiple build service nodes, this provides an opportunity to
 		// connect to a different backend that may already have the bundle in cache
 		return Promise.race([
-			bundler.getBundle(type, moduleInstallationPromise, moduleset, brand, bundleDetails),
+			bundler.getBundle(type, moduleInstallationPromise, moduleset, bundleDetails),
 			promiseTimeout(timeoutDurationMSec)
 		]).then(function (bundle) {
 

--- a/lib/middleware/outputDemo.js
+++ b/lib/middleware/outputDemo.js
@@ -97,11 +97,15 @@ module.exports = (app, middlewareOptions = {}) => {
 	return function outputDemo(req, res, next) {
 		const fullModuleName = req.params.fullModuleName;
 		const demoName = req.params.demoName;
-		const brand = req.query['brand'] || 'master';
+
+		const source = req.query['source'];
+		const brand = req.query['brand'];
 
 		const bundleDetails = {
 			demoName: demoName,
-			reqUrl: req.url
+			reqUrl: req.url,
+			source,
+			brand
 		};
 
 		const moduleSet = new ModuleSet([fullModuleName]);
@@ -125,7 +129,6 @@ module.exports = (app, middlewareOptions = {}) => {
 						'demo',
 						moduleInstallationPromise,
 						moduleSet,
-						brand,
 						bundleDetails
 					),
 					promiseTimeout(timeoutDurationMSec),

--- a/lib/middleware/outputModuleMetadata.js
+++ b/lib/middleware/outputModuleMetadata.js
@@ -20,8 +20,9 @@ module.exports = app => {
 
 	return (req, res, next) => {
 		const module = req.params.module;
-		const brand = req.query['brand'] || 'master';
-		return moduleMetadata.getContent(module, brand)
+		const source = req.query['source'];
+		const brand = req.query['brand'];
+		return moduleMetadata.getContent(module, brand, source)
 			.then(metadata => {
 				if (res.headersSent || res._buildservice_last_error) {
 					const err = new Error('successful metadata response after headers written?');

--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -30,7 +30,7 @@ ModuleMetadata.prototype = {
 	/**
 	 * Fetch module, test whether it builds, include manifests, readme, etc.
 	 */
-	getContent: Q.async(function* (fullModuleName, brand) {
+	getContent: Q.async(function* (fullModuleName, brand, source) {
 		const log = this.log;
 		const moduleset = new ModuleSet([fullModuleName]);
 		const module = moduleset.getResolvedModules()[0];
@@ -56,7 +56,11 @@ ModuleMetadata.prototype = {
 
 			// Builds CSS and JS in parallel, allows either to fail without throwing
 			yield tryall(['js', 'css'].map(function(type) {
-				const bundlePromise = this.bundler.getBundle(type, installationPromise, moduleset, brand, { minify: 'none' });
+				const bundlePromise = this.bundler.getBundle(type, installationPromise, moduleset, {
+					minify: 'none',
+					brand,
+					source
+				});
 
 				return bundlePromise.then(function(bundle) {
 					const streamFinished = Q.bufferStream(bundle.stream);

--- a/lib/routes/v2/bundles.js
+++ b/lib/routes/v2/bundles.js
@@ -4,6 +4,7 @@ const outputBundle = require('../../middleware/outputBundle');
 const requireModulesParameter = require('../../middleware/requireModulesParameter');
 const cleanModulesParameter = require('../../middleware/cleanModulesParameter');
 const cleanBrandParameter = require('../../middleware/cleanBrandParameter');
+const cleanSourceParameter = require('../../middleware/cleanSourceParameter');
 const cleanExportsParameter = require('../../middleware/cleanExportsParameter');
 
 module.exports = app => {
@@ -11,6 +12,7 @@ module.exports = app => {
 		/^\/v2\/bundles\/(css|js)/,
 		requireModulesParameter(),
 		cleanModulesParameter(),
+		cleanSourceParameter(),
 		cleanBrandParameter(),
 		cleanExportsParameter(),
 		outputBundle(app)

--- a/test/bowerdependenciestest.test.js
+++ b/test/bowerdependenciestest.test.js
@@ -26,7 +26,7 @@ suiteWithPackages('dependencies has_external_dependency', [], function(installdi
 		assert(!('test1' in list), 'Dependencies should not be listed explicitly');
 		assert(!('test-package1' in list), 'Dependencies should not be listed explicitly');
 
-		const cssStream = yield (new CssBundler({ log: log })).getContent(installation, moduleset, brand, { minify: true });
+		const cssStream = yield (new CssBundler({ log: log })).getContent(installation, moduleset, { minify: true, brand });
 		const css = yield testhelper.bufferStream(cssStream);
 		const cssWithoutComment = css.replace(/\/\*.*Shrinkwrap[\s\S]+?\*\/\s*/,'');
 		assert.equal(cssWithoutComment, '.o-test-component-brand:after{content:"master"}', 'Expected minified output from test-package2');

--- a/test/bundlercsstest.test.js
+++ b/test/bundlercsstest.test.js
@@ -17,7 +17,7 @@ suiteWithPackages('installation-css has_external_dependency', ['invalidcss', 'te
 		const installation = new ModuleInstallation(moduleset, {dir:installdir, log:log});
 
 		yield installation.install();
-		const css = yield testhelper.bufferStream(yield (new CssBundler({log:log})).getContent(installation, moduleset, brand,{minify:true}));
+		const css = yield testhelper.bufferStream(yield (new CssBundler({ log: log })).getContent(installation, moduleset, { minify: true, brand}));
 
 		const cssWithoutShrink = css.replace(/\/\*.*Shrinkwrap[\s\S]+?\*\/\s*/,'');
 		// assert.equal(cssWithoutShrink, '#test1{hello:world;silent-var:false;url:url(https://' + hostnames.preferred + '/v2/files/test-package1@*/README)}');

--- a/test/bundlerjstest.test.js
+++ b/test/bundlerjstest.test.js
@@ -30,7 +30,7 @@ suiteWithPackages('installation-js', ['invalidjs', 'js'], function(installdir){
 			const installation = yield installer.createInstallation(moduleset);
 			assert.instanceOf(installation, ModuleInstallation);
 
-			const result = yield testhelper.bufferStream(yield bundler.getContent(installation, moduleset, brand, { minify: false }));
+			const result = yield testhelper.bufferStream(yield bundler.getContent(installation, moduleset, { minify: false, brand }));
 			assert.include(result.toString(), 'console.log("what is this?")', 'Source code of file ' + file + ' should be in the output');
 		})));
 	});
@@ -42,7 +42,7 @@ suiteWithPackages('installation-js', ['invalidjs', 'js'], function(installdir){
 
 		yield installation.install();
 		try {
-			yield testhelper.bufferStream(yield (new JsBundler({ log: log })).getContent(installation, moduleset, brand, {minify:'none'}));
+			yield testhelper.bufferStream(yield (new JsBundler({ log: log })).getContent(installation, moduleset, { minify: 'none', brand}));
 		} catch(err) {
 			assert.include(err.message, 'Module not found: Error: Can\'t resolve \'missingmodule\'', 'Error from jsbundler should be included: ' + err.stack);
 			assert.notInclude(err.message, installdir, 'Should hide full path');
@@ -59,7 +59,7 @@ suiteWithPackages('installation-js', ['invalidjs', 'js'], function(installdir){
 
 		yield installation.install();
 		try {
-			yield testhelper.bufferStream(yield (new JsBundler({ log: log })).getContent(installation, moduleset, brand, {minify:'none'}));
+			yield testhelper.bufferStream(yield (new JsBundler({ log: log })).getContent(installation, moduleset, { minify: 'none', brand}));
 		} catch(err) {
 			assert.notInclude(err.message, 'missingmodule', 'Should use custom file');
 			assert.include(err.message, 'Unexpected character \'#\'', 'Should use custom file');

--- a/test/democompilertest.test.js
+++ b/test/democompilertest.test.js
@@ -17,7 +17,7 @@ suiteWithPackages('demo-compilation', [], function(installdir){
 		const installation = new ModuleInstallation(moduleset, {dir: installdir, log:log});
 		yield installation.install();
 
-		const result = yield testhelper.bufferStream(yield (new DemoCompiler({ log: log })).getContent(installation, moduleset, brand, {}));
+		const result = yield testhelper.bufferStream(yield (new DemoCompiler({ log: log })).getContent(installation, moduleset, {brand}));
 		assert.include(result, '<body>\n<div>\n</div>', 'Demo should be generated');
 	});
 
@@ -28,7 +28,7 @@ suiteWithPackages('demo-compilation', [], function(installdir){
 		yield installation.install();
 
 		try {
-			yield testhelper.bufferStream(yield (new DemoCompiler({ log: log })).getContent(installation, moduleset, brand, {}));
+			yield testhelper.bufferStream(yield (new DemoCompiler({ log: log })).getContent(installation, moduleset, {brand}));
 		} catch(err) {
 			assert.include(err.message, 'Couldn\'t find demos config path', '\'No config path found\' error should be thrown');
 			return;
@@ -44,7 +44,7 @@ suiteWithPackages('demo-compilation', [], function(installdir){
 		yield installation.install();
 
 		try {
-			yield testhelper.bufferStream(yield (new DemoCompiler({log:log})).getContent(installation, moduleset, brand, {}));
+			yield testhelper.bufferStream(yield (new DemoCompiler({log:log})).getContent(installation, moduleset, {brand}));
 		} catch(err) {
 			assert.notInclude(err.message, 'Couldn\'t find demos config path', 'Should find default origami.json config file');
 			assert.include(err.message, 'Unclosed section', 'Should throw correct mustache syntax error');

--- a/test/integration/v2-bundles-css.test.js
+++ b/test/integration/v2-bundles-css.test.js
@@ -131,6 +131,47 @@ describe('GET /v2/bundles/css', function() {
 		});
 	});
 
+	describe('when a module is requested with an invalid source param', function () {
+		const moduleName = 'o-layout@3.0.0';
+		const source = '^%^^£%$&@';
+
+		beforeEach(function () {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/css?modules=${moduleName}&newerthan=${now}&source=${source}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message ', function (done) {
+			this.request.expect(/must be a valid system code/i).end(done);
+		});
+
+	});
+
+	describe('when a module is requested for a valid source param', function () {
+		const moduleName = 'o-test-component@v1.0.34';
+		const source = 'test-source';
+
+		beforeEach(function () {
+			const now = (new Date()).toISOString();
+			this.request = request(this.app)
+				.get(`/v2/bundles/css?modules=${moduleName}&newerthan=${now}&source=${source}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function (done) {
+			this.request.expect(200).end(done);
+		});
+
+		it('should respond with css for the given source', function (done) {
+			this.request.expect(`/** Shrinkwrap URL:\n *    /v2/bundles/css?modules=o-test-component%401.0.34%2Co-autoinit%401.5.1&shrinkwrap=\n */\n.o-test-component{content:"${source}"}`).end(done);
+		});
+	});
+
 	describe('when the modules parameter is missing', function() {
 
 		beforeEach(function() {

--- a/test/moduleinstallationtest.test.js
+++ b/test/moduleinstallationtest.test.js
@@ -75,7 +75,7 @@ suite('installation-remote', function() {
 		assert.include(path, 'bower_components/o-forms/main.scss');
 		assert.notInclude(path, '..');
 
-		const cssStream = yield (new CssBundler({ log: log })).getContent(installation, moduleset, brand);
+		const cssStream = yield (new CssBundler({ log: log })).getContent(installation, moduleset, { brand });
 		const css = yield testhelper.bufferStream(cssStream);
 		assert.include(css, '.o-forms');
 	});

--- a/test/moduleinstallationtest.test.js
+++ b/test/moduleinstallationtest.test.js
@@ -36,7 +36,7 @@ suite('installation-remote', function() {
 		const exists = yield Q.all([pfs.pathExists(list.jquery.paths[0]), pfs.pathExists(list.lodash.paths[0])]);
 		assert.deepEqual([true,true], exists, 'Expected installed files to exist');
 
-		const jsStream = yield (new JsBundler({ log: log })).getContent(installation, moduleset, brand, {minify:'none'});
+		const jsStream = yield (new JsBundler({ log: log })).getContent(installation, moduleset, { minify: 'none', brand});
 
 		const jsContent = yield testhelper.bufferStream(jsStream);
 
@@ -53,7 +53,7 @@ suite('installation-remote', function() {
 		const installation = new ModuleInstallation(moduleset, { dir: tmpdir, log: log });
 
 		yield installation.install();
-		const jsStream = yield (new JsBundler({ log: log })).getContent(installation, moduleset, brand, {exportName:'myExportVariable'});
+		const jsStream = yield (new JsBundler({ log: log })).getContent(installation, moduleset, { exportName: 'myExportVariable', brand});
 		const jsContent = yield testhelper.bufferStream(jsStream);
 
 		assert.include(jsContent, 'myExportVariable');
@@ -87,7 +87,7 @@ suite('installation-remote', function() {
 
 		yield installation.install();
 		const bundler = new CssBundler({log:log});
-		const cssStream = yield bundler.getContent(installation, moduleset, brand, {minify:'none'});
+		const cssStream = yield bundler.getContent(installation, moduleset, { minify: 'none', brand});
 		const css = yield testhelper.bufferStream(cssStream);
 		assert.include(css, '/*', 'expected comments in unminified CSS');
 	});
@@ -97,7 +97,7 @@ suite('installation-remote', function() {
 		const brand = 'master';
 		const installation = new ModuleInstallation(moduleset, { dir: tmpdir, log: log });
 		yield installation.install();
-		const cssStream = yield (new CssBundler({ log: log })).getContent(installation, moduleset, brand, {minify:'none'});
+		const cssStream = yield (new CssBundler({ log: log })).getContent(installation, moduleset, { minify: 'none', brand});
 
 		const css = yield testhelper.bufferStream(cssStream);
 

--- a/test/unit/lib/middleware/cleanSourceParameter.test.js
+++ b/test/unit/lib/middleware/cleanSourceParameter.test.js
@@ -1,13 +1,14 @@
+
 'use strict';
 
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
 
-describe('lib/middleware/cleanBrandParameter', () => {
+describe('lib/middleware/cleanSourceParameter', () => {
     let httpError;
     let origamiService;
-    let cleanBrandParameter;
+    let cleanSourceParameter;
 
     beforeEach(() => {
         origamiService = require('../../mock/origami-service.mock');
@@ -15,18 +16,18 @@ describe('lib/middleware/cleanBrandParameter', () => {
         httpError = require('../../mock/http-errors.mock');
         mockery.registerMock('http-errors', httpError);
 
-        cleanBrandParameter = require('../../../../lib/middleware/cleanBrandParameter');
+        cleanSourceParameter = require('../../../../lib/middleware/cleanSourceParameter');
     });
 
     it('exports a function', () => {
-        assert.isFunction(cleanBrandParameter);
+        assert.isFunction(cleanSourceParameter);
     });
 
-    describe('cleanBrandParameter()', () => {
+    describe('cleanSourceParameter()', () => {
         let middleware;
 
         beforeEach(() => {
-            middleware = cleanBrandParameter();
+            middleware = cleanSourceParameter();
         });
 
         it('returns a middleware function', () => {
@@ -42,21 +43,22 @@ describe('lib/middleware/cleanBrandParameter', () => {
             });
 
             [
-                'intttternal',
-                '-invalid1',
+                'really-long-invalid-really-long-invalid-really-long-invalid-really-long-invalid-really-long-invalid-really-long-invalid-',
+                ' ',
+                'in_valid',
                 'inv@lid2',
                 'inva.lid3',
             ].forEach((value) => {
-                describe(`when the \'brand\' query string is invalid, containing the value '${value}'`, () => {
+                describe(`when the \'source\' query string is invalid, containing the value '${value}'`, () => {
 
                     beforeEach(() => {
-                        origamiService.mockRequest.query.brand = value;
+                        origamiService.mockRequest.query.source = value;
                         middleware(origamiService.mockRequest, origamiService.mockResponse, spyNext);
                     });
 
                     it('creates a 400 HTTP error', () => {
                         assert.calledOnce(httpError);
-                        assert.calledWithExactly(httpError, 400, 'The brand parameter must be one of: master, internal, whitelabel.');
+                        assert.calledWithExactly(httpError, 400, 'The "source" parameter must be a valid system code, according to v1.3 of the system code spec.');
                     });
 
                     it('calls `next` with the created error', () => {
@@ -66,10 +68,10 @@ describe('lib/middleware/cleanBrandParameter', () => {
                 });
             });
 
-            describe('when the `brand` query parameter is missing', () => {
+            describe('when the `source` query parameter is missing', () => {
 
                 beforeEach(() => {
-                    delete origamiService.mockRequest.query.brand;
+                    delete origamiService.mockRequest.query.source;
                     middleware(origamiService.mockRequest, origamiService.mockResponse, spyNext);
                 });
 
@@ -78,17 +80,17 @@ describe('lib/middleware/cleanBrandParameter', () => {
                     assert.calledWithExactly(spyNext);
                 });
 
-                it('sets request.query.brand to "master"', () => {
-                    assert.equal(origamiService.mockRequest.query.brand, 'master');
+                it('sets request.query.source to "build-service"', () => {
+                    assert.equal(origamiService.mockRequest.query.source, 'build-service');
                 });
             });
 
-            describe('when the `brand` query parameter is valid', () => {
+            describe('when the `source` query parameter is valid', () => {
 
-                const testBrandName = 'internal';
+                const testSourceName = 'a-valid-source-123';
 
                 beforeEach(() => {
-                    origamiService.mockRequest.query.brand = testBrandName;
+                    origamiService.mockRequest.query.source = testSourceName;
                     middleware(origamiService.mockRequest, origamiService.mockResponse, spyNext);
                 });
 
@@ -97,8 +99,8 @@ describe('lib/middleware/cleanBrandParameter', () => {
                     assert.calledWithExactly(spyNext);
                 });
 
-                it('does not modify request.query.brand', () => {
-                    assert.strictEqual(origamiService.mockRequest.query.brand, testBrandName);
+                it('does not modify request.query.source', () => {
+                    assert.strictEqual(origamiService.mockRequest.query.source, testSourceName);
                 });
             });
 

--- a/test/unit/lib/middleware/outputBundle.test.js
+++ b/test/unit/lib/middleware/outputBundle.test.js
@@ -215,7 +215,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.polyfills = 'none';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].babelRuntime, false);
+								assert.equal(bundler.getBundle.firstCall.args[3].babelRuntime, false);
 							});
 				});
 
@@ -223,7 +223,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.polyfills = '0';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].babelRuntime, false);
+								assert.equal(bundler.getBundle.firstCall.args[3].babelRuntime, false);
 							});
 				});
 
@@ -231,7 +231,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.polyfills = 'no';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].babelRuntime, false);
+								assert.equal(bundler.getBundle.firstCall.args[3].babelRuntime, false);
 							});
 				});
 
@@ -239,7 +239,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.polyfills = 'false';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].babelRuntime, false);
+								assert.equal(bundler.getBundle.firstCall.args[3].babelRuntime, false);
 							});
 				});
 
@@ -247,7 +247,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.polyfills = undefined;
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].babelRuntime, true);
+								assert.equal(bundler.getBundle.firstCall.args[3].babelRuntime, true);
 							});
 				});
 
@@ -255,7 +255,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.polyfills = 'test';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].babelRuntime, true);
+								assert.equal(bundler.getBundle.firstCall.args[3].babelRuntime, true);
 							});
 				});
 
@@ -264,7 +264,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.newerthan = now;
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].newerThan, Date.parse(now));
+								assert.equal(bundler.getBundle.firstCall.args[3].newerThan, Date.parse(now));
 							});
 				});
 
@@ -272,7 +272,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.newerthan = 'not a thing';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.isNaN(bundler.getBundle.firstCall.args[4].newerThan);
+								assert.isNaN(bundler.getBundle.firstCall.args[3].newerThan);
 							});
 				});
 
@@ -280,7 +280,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.newerthan = undefined;
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].newerThan, false);
+								assert.equal(bundler.getBundle.firstCall.args[3].newerThan, false);
 							});
 				});
 
@@ -290,7 +290,7 @@ describe('lib/middleware/outputBundle', function() {
 						.then(() => {
 								assert.calledTwice(ModuleSet);
 								assert.calledWithExactly(ModuleSet, [ 'o-test-component@1.0.17' ]);
-								assert.deepEqual(bundler.getBundle.firstCall.args[4].versionLocks, ModuleSet.mockModuleSet);
+								assert.deepEqual(bundler.getBundle.firstCall.args[3].versionLocks, ModuleSet.mockModuleSet);
 							});
 				});
 
@@ -298,7 +298,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.minify = 'none';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].minify, false);
+								assert.equal(bundler.getBundle.firstCall.args[3].minify, false);
 							});
 				});
 
@@ -306,7 +306,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.minify = undefined;
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].minify, true);
+								assert.equal(bundler.getBundle.firstCall.args[3].minify, true);
 							});
 				});
 
@@ -314,7 +314,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.minify = 'test';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].minify, true);
+								assert.equal(bundler.getBundle.firstCall.args[3].minify, true);
 							});
 				});
 
@@ -322,7 +322,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.export = 'salmon';
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].exportName, 'salmon');
+								assert.equal(bundler.getBundle.firstCall.args[3].exportName, 'salmon');
 							});
 				});
 
@@ -330,7 +330,7 @@ describe('lib/middleware/outputBundle', function() {
 					request.query.export = undefined;
 					return middleware(request, response, next)
 							.then(() => {
-								assert.equal(bundler.getBundle.firstCall.args[4].exportName, 'Origami');
+								assert.equal(bundler.getBundle.firstCall.args[3].exportName, 'Origami');
 							});
 				});
 			});

--- a/views/index.html
+++ b/views/index.html
@@ -122,6 +122,16 @@ o-typography:
 						<p>The polyfill mechanism is adding <a href="https://github.com/babel/babel/tree/c440f045f548ab60d15880a60b34511a7ffec931/packages/babel-runtime">babel-runtime</a> to the bundle if required. This is not a complete polyfill as it does not modify existing built-ins (<a href="https://babeljs.io/docs/plugins/transform-runtime">reference</a>) and as such doesn't work on instance methods, e.g. <code>'foo'.repeat(1)</code></p>
 					</td>
 				</tr><tr>
+					<td><code>brand</code></td>
+					<td>Querystring</td>
+					<td><em>(Optional)</em> The brand to build requested modules for. One of "master", "internal", or "whitelabel"</td>
+				</tr><tr>
+				</tr><tr>
+					<td><code>source</code></td>
+					<td>Querystring</td>
+					<td><em>(Optional)</em> The [bizops system code](https://biz-ops.in.ft.com/list/Systems) for the system which is making the build service request.</td>
+				</tr><tr>
+				</tr><tr>
 					<td><code>export</code></td>
 					<td>Querystring</td>
 					<td><em>(Optional)</em> If present, generates a <a href="https://github.com/umdjs/umd">UMD</a> bundle for the supplied export name. UMD works with other module systems and if no module system is found sets the specified name as a window global.  If absent, the default export name <code>Origami</code> will be used.  To export nothing, pass an empty string.</td>


### PR DESCRIPTION
**Overview**
 Add source query parameter:

- Optional until v3, falls back to "build-service" when not set.
- Used to set a global `$system-code` variable in Sass builds.
- Refactors a little to pass `brand` and `source` variables in the
builds `options` object, rather than a separate argument.

The `$system-code` Sass variable will be used by Origami components 
to set a source parameter on image service requests.

**Relates to:**
https://github.com/Financial-Times/origami-build-tools/pull/604
https://github.com/Financial-Times/o-footer-services/issues/10 
(and similar component issues)