### PR TITLE
Add a closing tag for the script tag

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -14,8 +14,8 @@
 		the FT webfonts:</strong>
 </p>
 <pre><code class="o-syntax-highlight--html">&lt;link rel=&quot;stylesheet&quot;
-href=&quot;https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; /&gt;
-&lt;script src=&quot;https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; async /&gt;</code></pre>
+href=&quot;https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot;&gt;
+&lt;script src=&quot;https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.0.0,o-fonts@^1.4.0&quot; async&gt;&lt;/script&gt;</code></pre>
 <p>This is all you need for prototyping with the Build Service. To use the Build Service in production you should also
 	include a <a href="http://origami.ft.com/docs/developer-guide/using-modules/#core-vs-enhanced-experience">cuts the
 		mustard test</a>.


### PR DESCRIPTION
Because we're not using XHTML, the `/` before the end of the script declaration does not self-close.
With this change, users can copy and paste the code in the block and paste it in their head and it will work.