### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -2,7 +2,7 @@ name: Deploy to staging
 on:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   deploy-to-staging:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -7,7 +7,7 @@ on:
 # on:
 #   push:
 #     branches:
-#       - 'master'
+#       - $default-branch
 
 jobs:
   run:
@@ -18,5 +18,5 @@ jobs:
         with:
           github_token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
           # branch: "npm-audit-fix"
-          # default_branch: "master"
+          # default_branch: $default-branch
           # commit_title: "chore(deps): npm audit fix"


### PR DESCRIPTION
This will help with any future work on renaming the default branch name.