### PR TITLE
Revert "Bump babel-runtime from 5.8.38 to 6.26.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2758,12 +2758,18 @@
       }
     },
     "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "version": "5.8.38",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+      "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "^1.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
       }
     },
     "babel-template": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-es2017": "^6.24.1",
     "babel-preset-es3": "^1.0.1",
-    "babel-runtime": "^6.26.0",
+    "babel-runtime": "^5.6.15",
     "bower-resolve-webpack-plugin": "^1.0.5",
     "falafel": "^1.2.0",
     "gulp-autoprefixer": "^3.1.0",


### PR DESCRIPTION
Reverts Financial-Times/origami-build-service#358