### PR TITLE
Deploy pull-requests to the dev app and not the staging app

### DIFF
--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
       - name: Deploy to Heroku
-        run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-build-service-qa.git HEAD:refs/heads/master --force
+        run: git push https://heroku:${{ secrets.HEROKU_AUTH_TOKEN }}@git.heroku.com/origami-build-service-dev.git HEAD:refs/heads/master --force
 
   create-change-log:
     needs: [deploy-dev]


### PR DESCRIPTION
🙈 luckily we do not use the heroku pipeline promotion feature when deploying to production because it we did we would have been deploying random pull-requests to production!