### PR TITLE
Wrap error messages in `pre` instead of `p`

### DIFF
--- a/views/error.html
+++ b/views/error.html
@@ -7,5 +7,5 @@
 		{{title}}
 	</h1>
 
-	<p data-test-id="error-message">{{error.message}}</p>
+	<pre data-test-id="error-message">{{error.message}}</pre>
 </div>


### PR DESCRIPTION
closes #132 and looks super cute

## before
![variable pitch error on a white background, all one line](https://user-images.githubusercontent.com/178266/101530891-6fdda980-398a-11eb-8566-56d1a411bd90.png)

## after
![monospace error on a grey background, with spacing](https://user-images.githubusercontent.com/178266/101531010-93a0ef80-398a-11eb-9d77-5d4f824ac292.png)
