### PR TITLE
Add v3/files endpoint 

### DIFF
--- a/lib/middleware/v3/createJavaScriptBundle.js
+++ b/lib/middleware/v3/createJavaScriptBundle.js
@@ -13,6 +13,7 @@ const { parseCallbackParameter } = require('./parseCallbackParameter');
 const { createPackageJsonFile } = require('./createPackageJsonFile');
 const { installDependencies } = require('./installDependencies');
 const { bundleJavascript } = require('./bundleJavascript');
+const { parseSystemCodeParameter } = require('./parseSystemCodeParameter');
 
 const rimrafOptions = {
 	glob: false,
@@ -46,6 +47,13 @@ const createJavaScriptBundle = async (request, response) => {
 		response.startTime('parseCallbackParameter');
 		const callback = await parseCallbackParameter(request.query.callback);
 		response.endTime('parseCallbackParameter');
+
+		response.startTime('parseSystemCodeParameter');
+		// Even though we do not use the system code we want to ensure
+		// the request has one to help us when we need to communicate
+		// to any users of this API endpoint.
+		parseSystemCodeParameter(request.query.system_code);
+		response.endTime('parseSystemCodeParameter');
 
 		response.startTime('createPackageJsonFile');
 		await createPackageJsonFile(bundleLocation, modules);

--- a/lib/middleware/v3/outputFile.js
+++ b/lib/middleware/v3/outputFile.js
@@ -1,0 +1,105 @@
+// @ts-nocheck
+'use strict';
+
+const fs = require('fs').promises;
+const fileExists = require('fs').existsSync;
+const util = require('util');
+const path = require('path');
+const rimraf = require('rimraf');
+const Raven = require('raven');
+const gracefulFs = require('graceful-fs');
+
+const { parseFileParameter } = require('./parseFileParameter');
+const { parseModuleParameter } = require('./parseModuleParameter');
+const { parseSystemCodeParameter } = require('./parseSystemCodeParameter');
+const { createPackageJsonFile } = require('./createPackageJsonFile');
+const { installDependencies } = require('./installDependencies');
+
+function getFilePath(bundleLocation, module, file) {
+	const moduleName = Object.keys(module)[0];
+	return path.join(bundleLocation, 'node_modules', moduleName, file);
+}
+
+
+const rmrf = util.promisify(rimraf);
+
+const rimrafOptions = {
+	glob: false,
+	unlink: gracefulFs.unlink,
+	unlinkSync: gracefulFs.unlinkSync,
+	chmod: gracefulFs.chmod,
+	chmodSync: gracefulFs.chmodSync,
+	stat: gracefulFs.stat,
+	statSync: gracefulFs.statSync,
+	lstat: gracefulFs.lstat,
+	lstatSync: gracefulFs.lstatSync,
+	rmdir: gracefulFs.rmdir,
+	rmdirSync: gracefulFs.rmdirSync,
+	readdir: gracefulFs.readdir,
+	readdirSync: gracefulFs.readdirSync
+};
+
+/**
+ * @param {import('express').Request} request
+ * @param {import('express').Response} response
+ */
+const outputFile = async (request, response) => {
+	await fs.mkdir('/tmp/bundle/', {recursive: true});
+	const bundleLocation = await fs.mkdtemp('/tmp/bundle/');
+	await fs.mkdir(bundleLocation, {recursive: true});
+
+	try {
+
+		response.startTime('parseModuleParameter');
+		const module = parseModuleParameter(request.query.module);
+		response.endTime('parseModuleParameter');
+
+		response.startTime('parseFileParameter');
+		const file = parseFileParameter(request.query.file);
+		response.endTime('parseFileParameter');
+
+		response.startTime('parseSystemCodeParameter');
+		// Even though we do not use the system code we want to ensure
+		// the request has one to help us when we need to communicate
+		// to any users of this API endpoint.
+		parseSystemCodeParameter(request.query.system_code);
+		response.endTime('parseSystemCodeParameter');
+
+		response.startTime('createPackageJsonFile');
+		await createPackageJsonFile(bundleLocation, module);
+		response.endTime('createPackageJsonFile');
+
+		response.startTime('installDependencies');
+		await installDependencies(bundleLocation, request.app.ft.options.npmRegistryURL);
+		response.endTime('installDependencies');
+
+		response.setHeader('Cache-Control', 'public, max-age=86400, stale-if-error=604800, stale-while-revalidate=300000');
+		const fileName = getFilePath(bundleLocation, module, file);
+
+		if (fileExists(fileName)) {
+			response.sendFile(fileName);
+		} else {
+			const moduleName = Object.keys(module)[0];
+			const version = Object.values(module)[0];
+			throw new Error(
+				`${moduleName}@${version} does not contain a file named '${file}'.`
+			);
+		}
+	} catch (err) {
+		Raven.captureException(err);
+		console.error(err, JSON.stringify(err));
+
+		response.setHeader('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store');
+		response.status(400);
+
+		response.send(`/*${JSON.stringify(
+			'Origami Build Service returned an error: ' + err.message
+		)}*/`);
+	} finally {
+		await rmrf(bundleLocation, rimrafOptions);
+	}
+};
+
+module.exports = {
+    outputFile
+};

--- a/lib/middleware/v3/parseFileParameter.js
+++ b/lib/middleware/v3/parseFileParameter.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const path = require('path');
+const UserError = require('../../utils/usererror');
+
+/**
+ *
+ * @param {string} [file] The path of the file to be returned.
+ * @throws {import('../../utils/usererror')}
+ * @returns {string|undefined}} The path of the file to be returned.
+ */
+const parseFileParameter = file => {
+	if (file === undefined) {
+		throw new UserError('The file query parameter must be a string.');
+	}
+
+	if (typeof file !== 'string') {
+		throw new UserError('The file query parameter must be a string.');
+	}
+
+	if (file.length === 0) {
+		throw new UserError('The file query parameter can not be an empty string.');
+	}
+
+	if (isAttemptingToTraverseParentDirectories(file)) {
+		throw new UserError(
+			'The file query parameter must be a path within the requested component.'
+		);
+	} else {
+		return file;
+	}
+};
+
+function isAttemptingToTraverseParentDirectories(filePath) {
+	const filename = path.join(__dirname, filePath);
+	if (!filename.startsWith(__dirname)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+module.exports = {
+    parseFileParameter
+};

--- a/lib/middleware/v3/parseModuleParameter.js
+++ b/lib/middleware/v3/parseModuleParameter.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const validateNpmPackageName = require('validate-npm-package-name');
+const UserError = require('../../utils/usererror');
+const semver = require('semver');
+
+/**
+ * Used to ensure the requested module in the module query parameter conforms to the package.json specification.
+ * https://docs.npmjs.com/files/package.json#name
+ *
+ * If the module name is valid, return a Map of module name to version range.
+ * If the module name is not valid, return an Error HTTP 400 status code, specifying that the module name is invalid.
+ *
+ * @param {string} module The module to validate
+ * @throws {import('../../utils/usererror')}
+ * @returns {Object<string, string>|{}}} A Map where the key is the module name and the value is the version range
+ */
+const parseModuleParameter = module => {
+	if (module === undefined || module.length === 0) {
+		throw new UserError('The module query parameter can not be empty.');
+	}
+
+	if (typeof module !== 'string') {
+		throw new UserError('The module query parameter must be a string.');
+	}
+
+	if (/^\s/.test(module) || /\s$/.test(module)) {
+		throw new UserError(
+			`The module query parameter contains whitespace either the start or end. Remove the whitespace from "${module}" to make the module name valid.`
+		);
+	}
+
+	let moduleName;
+	if (module.startsWith('@')) {
+		moduleName = '@' + module.split('@')[1];
+	} else {
+		moduleName = module.split('@')[0];
+	}
+
+	if (!isValidNpmModuleName(moduleName)) {
+		throw new UserError(
+			`The module query parameter contains a name which is not valid: ${moduleName}.`
+		);
+	}
+
+	const dependencies = {};
+	if (!(module.lastIndexOf('@') > 0)) {
+		throw new UserError(
+			`The module query parameter contains ${module} with no version range, a version range is required.\nPlease refer to TODO (build service documentation) for what is a valid version.`
+		);
+	}
+
+	const name = module.substr(0, module.lastIndexOf('@'));
+	const version = module.substr(module.lastIndexOf('@') + 1);
+	if (semver.validRange(version)) {
+		dependencies[name] = version;
+	} else {
+		throw new UserError(`The version ${version} in ${name}@${version} is not a valid version.\nPlease refer to TODO (build service documentation) for what is a valid version.`);
+	}
+
+	return dependencies;
+};
+
+/**
+ * Checks an npm module name conforms to the package.json specification.
+ * @param {String} name An npm module name.
+ * @returns {Boolean} Whether the name parameter is valid according to package.json specification.
+ */
+function isValidNpmModuleName(name) {
+	return validateNpmPackageName(name).validForNewPackages;
+}
+
+module.exports = {
+    parseModuleParameter
+};

--- a/lib/routes/v3/files.js
+++ b/lib/routes/v3/files.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const outputFile = require('../../middleware/v3/outputFile').outputFile;
+
+module.exports = app => {
+	app.get(
+		'/v3/files',
+		outputFile
+	);
+};

--- a/test/integration/v3-bundles-js.test.js
+++ b/test/integration/v3-bundles-js.test.js
@@ -123,7 +123,7 @@ describe('GET /v3/bundles/js', function() {
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get('/v3/bundles/js?system_code=${system}')
+                .get(`/v3/bundles/js?system_code=${system}`)
                 .set('Connection', 'close');
         });
 
@@ -146,7 +146,7 @@ describe('GET /v3/bundles/js', function() {
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get('/v3/bundles/js?modules[]=foo&modules[]=bar&system_code=${system}')
+                .get(`/v3/bundles/js?modules[]=foo&modules[]=bar&system_code=${system}`)
                 .set('Connection', 'close');
         });
 

--- a/test/integration/v3-bundles-js.test.js
+++ b/test/integration/v3-bundles-js.test.js
@@ -36,10 +36,11 @@ describe('GET /v3/bundles/js', function() {
 
     describe('when a valid module is requested', function() {
         const moduleName = '@financial-times/o-utils@1.1.7';
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get(`/v3/bundles/js?modules=${moduleName}`)
+                .get(`/v3/bundles/js?modules=${moduleName}&system_code=${system}`)
                 .set('Connection', 'close');
         });
 
@@ -76,10 +77,11 @@ describe('GET /v3/bundles/js', function() {
 
     describe('when an invalid module is requested (nonexistent)', function() {
         const moduleName = 'hello-nonexistent-module@1';
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get(`/v3/bundles/js?modules=${moduleName}`)
+                .get(`/v3/bundles/js?modules=${moduleName}&system_code=${system}`)
                 .set('Connection', 'close');
         });
 
@@ -117,10 +119,11 @@ describe('GET /v3/bundles/js', function() {
     // });
 
     describe('when the modules parameter is missing', function() {
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get('/v3/bundles/js')
+                .get('/v3/bundles/js?system_code=${system}')
                 .set('Connection', 'close');
         });
 
@@ -139,10 +142,11 @@ describe('GET /v3/bundles/js', function() {
     });
 
     describe('when the modules parameter is not a string', function() {
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get('/v3/bundles/js?modules[]=foo&modules[]=bar')
+                .get('/v3/bundles/js?modules[]=foo&modules[]=bar&system_code=${system}')
                 .set('Connection', 'close');
         });
 
@@ -162,10 +166,11 @@ describe('GET /v3/bundles/js', function() {
 
     describe('when a module name cannot be parsed', function() {
         const moduleName = 'http://1.2.3.4/';
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get(`/v3/bundles/js?modules=${moduleName}`)
+                .get(`/v3/bundles/js?modules=${moduleName}&system_code=${system}`)
                 .set('Connection', 'close');
         });
 
@@ -187,10 +192,11 @@ describe('GET /v3/bundles/js', function() {
     describe('when the callback parameter is an invalid value', function() {
         const moduleName = '@financial-times/o-utils@1.1.7';
         const callback = 'console.log("you got hacked!");//';
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get(`/v3/bundles/js?modules=${moduleName}&callback=${callback}`)
+                .get(`/v3/bundles/js?modules=${moduleName}&callback=${callback}&system_code=${system}`)
                 .set('Connection', 'close');
         });
 
@@ -213,10 +219,11 @@ describe('GET /v3/bundles/js', function() {
     describe('when the callback parameter is a valid value', function() {
         const moduleName = '@financial-times/o-utils@1.1.7';
         const callback = 'start_app';
+        const system = 'origami-build-service';
 
         beforeEach(function() {
             this.request = request(this.app)
-                .get(`/v3/bundles/js?modules=${moduleName}&callback=${callback}`)
+                .get(`/v3/bundles/js?modules=${moduleName}&callback=${callback}&system_code=${system}`)
                 .set('Connection', 'close');
         });
 

--- a/test/integration/v3-file.test.js
+++ b/test/integration/v3-file.test.js
@@ -1,0 +1,237 @@
+'use strict';
+
+const proclaim = require('proclaim');
+const request = require('supertest');
+
+describe('GET /v3/files', function () {
+	this.timeout(20000);
+	this.slow(5000);
+
+	describe('when a valid module is requested', function () {
+		const moduleName = '@financial-times/o-table@*';
+		const file = 'package.json';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(
+					`/v3/files?module=${moduleName}&file=${file}&system_code=${system}`
+				)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with the requested file', function (done) {
+			this.request
+				.expect(({text}) => {
+					const moduleName = JSON.parse(text).name;
+					proclaim.deepEqual(moduleName, '@financial-times/o-table');
+				})
+				.end(done);
+		});
+
+		it('should respond with a 200 status', function (done) {
+			this.request.expect(200).end(done);
+		});
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request
+				.expect('Content-Type', 'application/json; charset=UTF-8')
+				.end(done);
+		});
+	});
+
+	describe('when an invalid module is requested (nonexistent)', function () {
+		const moduleName = 'hello-nonexistent-module@1';
+		const file = 'package.json';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(
+					`/v3/files?module=${moduleName}&file=${file}&system_code=${system}`
+				)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(({text}) => {
+					proclaim.deepEqual(
+						text,
+						'/*"Origami Build Service returned an error: hello-nonexistent-module@1 is not in the npm regsitry"*/'
+					);
+				})
+				.end(done);
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		});
+	});
+
+	describe('when the file requested does not exist', function () {
+		const moduleName = 'o-test-component@1.0.1';
+		const file = 'non-existant-file.magic';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(
+					`/v3/files?module=${moduleName}&file=${file}&system_code=${system}`
+				)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(({text}) => {
+					proclaim.deepEqual(
+						text,
+						'/*"Origami Build Service returned an error: o-test-component@1.0.1 does not contain a file named \'non-existant-file.magic\'."*/'
+					);
+				})
+				.end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		});
+	});
+
+	describe('when the module parameter is missing', function () {
+		const file = 'package.json';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(`/v3/files?file=${file}&system_code=${system}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(
+					'/*"Origami Build Service returned an error: The module query parameter can not be empty."*/'
+				)
+				.end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request
+				.expect('Content-Type', 'text/html; charset=utf-8')
+				.end(done);
+		});
+	});
+
+	describe('when the module parameter is not a string', function () {
+		const file = 'package.json';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(
+					`/v3/files?module[]=foo&module[]=bar&file=${file}&system_code=${system}`
+				)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(
+					'/*"Origami Build Service returned an error: The module query parameter must be a string."*/'
+				)
+				.end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request
+				.expect('Content-Type', 'text/html; charset=utf-8')
+				.end(done);
+		});
+	});
+
+	describe('when a module name cannot be parsed', function () {
+		const moduleName = 'http://1.2.3.4/';
+		const file = 'package.json';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(
+					`/v3/files?module=${moduleName}&file=${file}&system_code=${system}`
+				)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(({text}) => {
+					proclaim.deepStrictEqual(
+						text,
+						'/*"Origami Build Service returned an error: The module query parameter contains a name which is not valid: http://1.2.3.4/."*/'
+					);
+				})
+				.end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request
+				.expect('Content-Type', 'text/html; charset=utf-8')
+				.end(done);
+		});
+	});
+
+	describe('when the file parameter is an invalid value', function () {
+		const moduleName = '@financial-times/o-utils@1.1.7';
+		const file = '../package.json';
+		const system = 'origami-build-service';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(
+					`/v3/files?module=${moduleName}&file=${file}&system_code=${system}`
+				)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(({text}) => {
+					proclaim.deepStrictEqual(
+						text,
+						'/*"Origami Build Service returned an error: The file query parameter must be a path within the requested component."*/'
+					);
+				})
+				.end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function (done) {
+			this.request
+				.expect('Content-Type', 'text/html; charset=utf-8')
+				.end(done);
+		});
+	});
+});

--- a/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
+++ b/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
@@ -34,6 +34,7 @@ describe('createJavaScriptBundle', function () {
 				}
 			};
 			request.query.modules = '@financial-times/o-utils@1.1.7';
+			request.query.system_code = 'origami-build-service';
 
 			await createJavaScriptBundle(request, response);
 
@@ -80,6 +81,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				}
 			};
+			request.query.system_code = 'origami-build-service';
 
 			await createJavaScriptBundle(request, response);
 
@@ -127,6 +129,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = '';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -175,6 +178,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = 'o-test@1,o-test@1';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -222,6 +226,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = 'o-test@1,,';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -269,6 +274,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = ' o-test@1';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -316,6 +322,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = 'o-test@1 ';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -363,6 +370,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = 'o-test';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -410,6 +418,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = 'o-test@5wg';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 
@@ -457,6 +466,7 @@ describe('createJavaScriptBundle', function () {
 					}
 				};
 				request.query.modules = 'o-TeSt@5';
+				request.query.system_code = 'origami-build-service';
 
 				await createJavaScriptBundle(request, response);
 

--- a/test/unit/lib/middleware/v3/parseFileParameter.test.js
+++ b/test/unit/lib/middleware/v3/parseFileParameter.test.js
@@ -7,7 +7,7 @@ const {
 	parseFileParameter,
 } = require('../../../../../lib/middleware/v3/parseFileParameter');
 
-describe.only('parseFileParameter', () => {
+describe('parseFileParameter', () => {
 	it('it is a function', async () => {
 		proclaim.isFunction(parseFileParameter);
 	});

--- a/test/unit/lib/middleware/v3/parseFileParameter.test.js
+++ b/test/unit/lib/middleware/v3/parseFileParameter.test.js
@@ -1,0 +1,90 @@
+/* eslint-env mocha */
+'use strict';
+
+const proclaim = require('proclaim');
+const UserError = require('../../../../../lib/utils/usererror');
+const {
+	parseFileParameter,
+} = require('../../../../../lib/middleware/v3/parseFileParameter');
+
+describe.only('parseFileParameter', () => {
+	it('it is a function', async () => {
+		proclaim.isFunction(parseFileParameter);
+	});
+	it('throws UserError if file parameter is an empty string', async () => {
+		proclaim.throws(() => {
+			parseFileParameter('');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter('');
+		}, 'The file query parameter can not be an empty string.');
+	});
+
+	it('throws UserError if file parameter is not undefined or a string', async () => {
+		proclaim.throws(() => {
+			parseFileParameter(null);
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter(null);
+		}, 'The file query parameter must be a string.');
+
+		proclaim.throws(() => {
+			parseFileParameter([1,2]);
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter([1,2]);
+		}, 'The file query parameter must be a string.');
+
+		proclaim.throws(() => {
+			parseFileParameter(12);
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter(12);
+		}, 'The file query parameter must be a string.');
+
+		proclaim.throws(() => {
+			parseFileParameter(true);
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter(true);
+		}, 'The file query parameter must be a string.');
+	});
+
+	it('throws UserError if file parameter is attempting to reference a file outside of the component\'s folder', async () => {
+		proclaim.throws(() => {
+			parseFileParameter('../../../etc/passwd');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter('../../../etc/passwd');
+		}, 'The file query parameter must be a path within the requested component.');
+
+		proclaim.throws(() => {
+			parseFileParameter('./hello/../../secret-file.txt');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseFileParameter('./hello/../../secret-file.txt');
+		}, 'The file query parameter must be a path within the requested component.');
+	});
+
+	it('returns file parameter if it is a valid value', async () => {
+		proclaim.deepStrictEqual(
+			parseFileParameter(
+				'./origami.json'
+			),
+			'./origami.json'
+		);
+		proclaim.deepStrictEqual(
+			parseFileParameter(
+				'./src/js/main.js'
+			),
+			'./src/js/main.js'
+		);
+	});
+});

--- a/test/unit/lib/middleware/v3/parseModuleParameters.test.js
+++ b/test/unit/lib/middleware/v3/parseModuleParameters.test.js
@@ -7,7 +7,7 @@ const {
 	parseModuleParameter,
 } = require('../../../../../lib/middleware/v3/parseModuleParameter');
 
-describe.only('parseModuleParameter', () => {
+describe('parseModuleParameter', () => {
 	it('it is a function', async () => {
 		proclaim.isFunction(parseModuleParameter);
 	});

--- a/test/unit/lib/middleware/v3/parseModuleParameters.test.js
+++ b/test/unit/lib/middleware/v3/parseModuleParameters.test.js
@@ -1,0 +1,102 @@
+/* eslint-env mocha */
+'use strict';
+
+const proclaim = require('proclaim');
+const UserError = require('../../../../../lib/utils/usererror');
+const {
+	parseModuleParameter,
+} = require('../../../../../lib/middleware/v3/parseModuleParameter');
+
+describe.only('parseModuleParameter', () => {
+	it('it is a function', async () => {
+		proclaim.isFunction(parseModuleParameter);
+	});
+	it('throws UserError if module parameter is an empty string', async () => {
+		proclaim.throws(() => {
+			parseModuleParameter('');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseModuleParameter('');
+		}, 'The module query parameter can not be empty.');
+	});
+
+	it('throws UserError if module parameter is a module name with whitespace at the start', async () => {
+		proclaim.throws(() => {
+			parseModuleParameter(' o-test@1');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseModuleParameter(' @ft/o-test@1');
+		}, 'The module query parameter contains whitespace either the start or end. Remove the whitespace from " @ft/o-test@1" to make the module name valid.');
+	});
+
+	it('throws UserError if module parameter is a module name with whitespace at the end', async () => {
+		proclaim.throws(() => {
+			parseModuleParameter('o-test@1 ');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseModuleParameter('o-test@1 ');
+		}, 'The module query parameter contains whitespace either the start or end. Remove the whitespace from "o-test@1 " to make the module name valid.');
+
+		proclaim.throws(() => {
+			parseModuleParameter('@ft/o-test@1 ');
+		}, 'The module query parameter contains whitespace either the start or end. Remove the whitespace from "@ft/o-test@1 " to make the module name valid.');
+	});
+
+	it('throws UserError if module parameter is a module name without a version', async () => {
+		proclaim.throws(() => {
+			parseModuleParameter('o-test');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseModuleParameter('o-test');
+		}, 'The module query parameter contains o-test with no version range, a version range is required.\nPlease refer to TODO (build service documentation) for what is a valid version.');
+
+		proclaim.throws(() => {
+			parseModuleParameter('@ft/o-test');
+		}, 'The module query parameter contains @ft/o-test with no version range, a version range is required.\nPlease refer to TODO (build service documentation) for what is a valid version.');
+	});
+
+	it('throws UserError if module parameter is a module name with an invalid version', async () => {
+		proclaim.throws(() => {
+			parseModuleParameter('o-test@5wg');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseModuleParameter('o-test@5wg');
+		}, 'The version 5wg in o-test@5wg is not a valid version.\nPlease refer to TODO (build service documentation) for what is a valid version.');
+
+		proclaim.throws(() => {
+			parseModuleParameter('@ft/o-test@5wg');
+		}, 'The version 5wg in @ft/o-test@5wg is not a valid version.\nPlease refer to TODO (build service documentation) for what is a valid version.');
+	});
+
+	it('throws UserError if module parameter contains an invalid module name', async () => {
+		proclaim.throws(() => {
+			parseModuleParameter('o-TeSt@5');
+		}, UserError);
+
+		proclaim.throws(() => {
+			parseModuleParameter('o-TeSt@5');
+		}, 'The module query parameter contains a name which is not valid: o-TeSt.');
+
+		proclaim.throws(() => {
+			parseModuleParameter('@ft/o-TeSt@5');
+		}, 'The module query parameter contains a name which is not valid: @ft/o-TeSt.');
+	});
+
+	it('returns an object where the key is the module name and the value is the version range', async () => {
+		const module = {
+			'@financial-times/o-table': '100',
+		};
+
+		proclaim.deepStrictEqual(
+			parseModuleParameter(
+				'@financial-times/o-table@100'
+			),
+			module
+		);
+	});
+});

--- a/views/apiv3.html
+++ b/views/apiv3.html
@@ -43,7 +43,7 @@
             <tr id="js-system_code">
                 <td><code>system_code</code></td>
                 <td>Querystring</td>
-                <td>The [bizops system code](https://biz-ops.in.ft.com/list/Systems) for the system which is making the build service request.</td>
+                <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
             </tr>
             <tr id="js-callback">
                 <td><code>callback</code></td>
@@ -97,7 +97,7 @@
             <tr id="css-system_code">
                 <td><code>system_code</code></td>
                 <td>Querystring</td>
-                <td>The [bizops system code](https://biz-ops.in.ft.com/list/Systems) for the system which is making the build service request.</td>
+                <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
             </tr>
         </tbody>
 
@@ -113,5 +113,52 @@
         <li><code>409 Conflict</code>: There was a dependency conflict in the bundle of modules specified</li>
         <li><code>500 Internal Server Error</code>: There was a server error with the build service</li>
         <li><code>560 Compilation Error</code> (non-standard): There was an error compiling the module code, reported from the build tools. This is likely an issue with the module, not with the build service itself</li>
+    </ul>
+
+    <h3 id="get-v3-files">GET /v3/files</h3>
+
+    <p>Fetch a specific file from a module.</p>
+
+    <table class="o-table o-table--horizontal-lines o-table--row-headings o-table--sortable" data-o-component="o-table" >
+        <thead>
+            <tr>
+                <th>Param</th>
+                <th data-o-table-heading-disable-sort>Where</th>
+                <th data-o-table-heading-disable-sort>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr id="files-modules">
+                <td><code>module</code></td>
+                <td>Querystring</td>
+                <td>
+                    A module in the form <code>module@version</code>.
+                    <code>module</code> is the name of the module on the <a href="https://www.npmjs.com/">npm registry</a>
+                    <code>version</code> will be interpreted using SemVer rules and the
+                    best matching version will be used.
+                </td>
+            </tr>
+            <tr id="css-brand">
+                <td><code>file</code></td>
+                <td>Querystring</td>
+                <td>The path to the file to have returned.</td>
+            </tr>
+            <tr id="css-system_code">
+                <td><code>system_code</code></td>
+                <td>Querystring</td>
+                <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
+            </tr>
+        </tbody>
+
+        <tbody></tbody>
+    </table>
+
+    <p><em>Due to the expected long duration of downloading from npm, this method may return a redirect to keep the connection alive while the build continues in the background.</em></p>
+
+    <p>The following HTTP errors can be returned:</p>
+
+    <ul>
+        <li><code>400 Bad Request</code>: The request was invalid</li>
+        <li><code>500 Internal Server Error</code>: There was a server error with the build service</li>
     </ul>
 </div>

--- a/views/migration.html
+++ b/views/migration.html
@@ -22,8 +22,8 @@
     <p>version 2 only used uri path parameters for the api and not any query parameters (<code>GET /v2/files/module@version/path</code>) whereas version 3 uses only query parameters and not path parameters (<code>GET /v3/files?module=...&file=...&system_code=...</code>)</p>
 
     <h4>Migration Example</h4>
-    From: <code>/v2/files/o-table@8/README.md</code>
-    To: <code>/v3/files?module=@financial-times/o-table@8&file=README.md&system_code=origami-build-service</code>
+    <p>From: <code>/v2/files/o-table@8/README.md</code></p>
+    <p>To: <code>/v3/files?module=@financial-times/o-table@8&file=README.md&system_code=origami-build-service</code></p>
 
     <h3>CSS endpoint</h3>
 

--- a/views/migration.html
+++ b/views/migration.html
@@ -15,11 +15,23 @@
 
     <p>Version 3 uses npm instead of Bower to install the requested components. You will need to update your Origami Build Service urls to use the npm package names instead of the bower package names for the components you are using. For most Origami components that means putting <code>@financial-times/</code>at the beginning of the name.</p>
 
+    <p>Version 3 has removed the <code>/modules</code> endpoint.</p>
+
+    <h3>Files endpoint</h3>
+
+    <p>version 2 only used uri path parameters for the api and not any query parameters (<code>GET /v2/files/module@version/path</code>) whereas version 3 uses only query parameters and not path parameters (<code>GET /v3/files?module=...&file=...&system_code=...</code>)</p>
+
+    <h4>Migration Example</h4>
+    From: <code>/v2/files/o-table@8/README.md</code>
+    To: <code>/v3/files?module=@financial-times/o-table@8&file=README.md&system_code=origami-build-service</code>
+
+    <h3>CSS endpoint</h3>
+
     <p>Version 3 no longer uses LibSass for compiling Sass and instead uses <a href="https://sass-lang.com/dart-sass">DartSass</a>.</p>
 
-    <p>Version 3 no longer uses Webpack for bundling JavaScript and instead uses <a href="https://esbuild.github.io/">ESBuild</a>.</p>
+    <h3>JS endpoint</h3>
 
-    <p>Version 3 has removed the <code>/modules</code> endpoint.</p>
+    <p>Version 3 no longer uses Webpack for bundling JavaScript and instead uses <a href="https://esbuild.github.io/">ESBuild</a>.</p>
 
     <p>The <code>/bundles/js</code> endpoint has removed support for several configuration parameters which are listed below:</p>
 
@@ -69,6 +81,10 @@
             <tr>
                 <td><code>/v2/bundles/js?modules=o-table&hellip;</code></td>
                 <td><code>/v3/bundles/js?modules=@financial-times/o-table&hellip;</code></td>
+            </tr>
+            <tr>
+                <td><code>/v2/files/o-table@8/README.md</code></td>
+                <td><code>/v3/files?module=@financial-times/o-table@8&file=README.md&system_code=origami-build-service</code></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
This adds the files endpoint to the version 3 of the API, which supports npm instead of bower (origami v2 components).

Differences from version 2 files endpoint:

- version 2 only used uri path parameters for the api and not any query parameters (`GET /v2/files/module@version/path` whereas version 3 uses only query parameters and not path parameters (`GET /v3/files?module=...&file=...&system_code=...`)

- version 3 requires a system_code query parameter to be present, which is the biz-ops system code for whatever is making the API call

- version 3 uses the npm registry instead of the bower registry

Screenshot of the documentation -- https://origami-build-service-dev.herokuapp.com/v3/docs/api#get-v3-files
![image](https://user-images.githubusercontent.com/1569131/102089248-dee85180-3e13-11eb-9c7a-ca6de927acd6.png)


Screenshot of the migration notes --
![image](https://user-images.githubusercontent.com/1569131/102089679-75b50e00-3e14-11eb-85f9-210b0e4db382.png)

