### PR TITLE
Enable integration tests to run against a live site

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: ['**/*.test.js'],
+			files: ['**/*.test.js', 'test/testhelper.js'],
 			env: {
 				mocha: true,
 			},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,13 +38,7 @@ module.exports = {
 				mocha: true,
 			},
 			'globals': {
-				'after': true,
-				'afterEach': true,
-				'before': true,
-				'beforeEach': true,
-				'describe': true,
 				'fetch': true,
-				'it': true,
 				'spawnTest': true,
 				'spawnTestWithTempdir': true,
 				'describeWithPackages': true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,16 +31,24 @@ module.exports = {
 		'prefer-const': 1,
 		'no-const-assign': 2
 	},
-	'globals': {
-		'after': true,
-		'afterEach': true,
-		'before': true,
-		'beforeEach': true,
-		'describe': true,
-		'fetch': true,
-		'it': true,
-		'spawnTest': true,
-		'spawnTestWithTempdir': true,
-		'describeWithPackages': true
-	}
+	overrides: [
+		{
+			files: ['**/*.test.js'],
+			env: {
+				mocha: true,
+			},
+			'globals': {
+				'after': true,
+				'afterEach': true,
+				'before': true,
+				'beforeEach': true,
+				'describe': true,
+				'fetch': true,
+				'it': true,
+				'spawnTest': true,
+				'spawnTestWithTempdir': true,
+				'describeWithPackages': true
+			}
+		},
+	],
 };

--- a/.github/workflows/deploy-to-dev-and-test.yml
+++ b/.github/workflows/deploy-to-dev-and-test.yml
@@ -22,3 +22,15 @@ jobs:
           system-code: "origami-build-service"
           environment: dev
           slack-channels: "ft-changes,origami-deploys"
+
+  integration-tests:
+    needs: [deploy-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 12.x
+      - run: npm install -g "npm@^7"
+      - run: npm ci
+      - run: HOST="https://origami-build-service-dev.herokuapp.com" make test-integration

--- a/.github/workflows/deploy-to-staging-and-test.yml
+++ b/.github/workflows/deploy-to-staging-and-test.yml
@@ -24,3 +24,15 @@ jobs:
           system-code: "origami-build-service"
           environment: test
           slack-channels: "ft-changes,origami-deploys"
+
+  integration-tests:
+    needs: [deploy-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 12.x
+      - run: npm install -g "npm@^7"
+      - run: npm ci
+      - run: HOST="https://origami-build-service-qa.herokuapp.com" make test-integration

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ make verify
 
 We run the tests and linter on CI, you can view [results on CI][ci]. `make test` and `make verify` must pass before we merge a pull request.
 
+You can run the integration tests against a URL by setting a `HOST` environment variable to the URL you want to test. This is useful for testing a Heroku application after it is deployed, which we do on CI.
+
+```sh
+HOST="https://www.example.com" make test-integration
+```
+
 
 Deployment
 ----------

--- a/test/integration/about.test.js
+++ b/test/integration/about.test.js
@@ -25,10 +25,14 @@ describe('GET /__about', function () {
 		this.request.expect(function (res) {
 			proclaim.isObject(res.body);
 
-			// we have to remove the dateDeployed key as it doesn't match
 			const aboutInfo = Object.assign({}, require('../../about.json'));
+			// we have to remove the dateDeployed key as it doesn't match
 			delete res.body.dateDeployed;
 			delete aboutInfo.dateDeployed;
+
+			// we have to remove the appVersion and _hostname as will be different when running the tests against the real servers.
+			delete res.body.appVersion;
+			delete res.body._hostname;
 			proclaim.deepEqual(res.body, aboutInfo);
 		}).end(done);
 	});

--- a/test/integration/about.test.js
+++ b/test/integration/about.test.js
@@ -30,7 +30,7 @@ describe('GET /__about', function () {
 			delete res.body.dateDeployed;
 			delete aboutInfo.dateDeployed;
 
-			// we have to remove the appVersion and _hostname as will be different when running the tests against the real servers.
+			// we have to remove the appVersion and _hostname as they will be different when running the tests against remote servers.
 			delete res.body.appVersion;
 			delete res.body._hostname;
 			delete aboutInfo.appVersion;

--- a/test/integration/about.test.js
+++ b/test/integration/about.test.js
@@ -33,6 +33,8 @@ describe('GET /__about', function () {
 			// we have to remove the appVersion and _hostname as will be different when running the tests against the real servers.
 			delete res.body.appVersion;
 			delete res.body._hostname;
+			delete aboutInfo.appVersion;
+			delete aboutInfo._hostname;
 			proclaim.deepEqual(res.body, aboutInfo);
 		}).end(done);
 	});

--- a/test/integration/bundles-css.test.js
+++ b/test/integration/bundles-css.test.js
@@ -21,50 +21,52 @@ describe('GET /bundles/css', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});
 
-	describe('when a module is requested that has a static bundle', function() {
-		const moduleName = 'mock-modules/test-static';
+	if (!process.env.HOST) {
+		describe('when a module is requested that has a static bundle', function() {
+			const moduleName = 'mock-modules/test-static';
 
-		beforeEach(function() {
-			this.request = request(this.app)
-				.get(`/bundles/css?modules=${moduleName}`)
-				.set('Connection', 'close');
+			beforeEach(function() {
+				this.request = request(this.app)
+					.get(`/bundles/css?modules=${moduleName}`)
+					.set('Connection', 'close');
+			});
+
+			it('should respond with a 200 status', function(done) {
+				this.request.expect(200).end(done);
+			});
+
+			it('should respond with the expected `Content-Type` header', function(done) {
+				this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
+			});
+
+			it('should respond with the contents of the static bundle', function(done) {
+				this.request.expect('/* STATIC BUNDLE (bundles/css) */\n').end(done);
+			});
+
+			it('should ignore URL encoding when checking for static bundles', function(done) {
+				const pathUnencoded = `/bundles/css?modules=${moduleName}^1.0.0`;
+				const pathEncoded = `/bundles/css?modules=${moduleName}%5E1.0.0`;
+				const expectedContent = '/* STATIC BUNDLE (bundles/css) */\n';
+
+				request(this.app)
+					.get(pathUnencoded)
+					.set('Connection', 'close')
+					.expect(expectedContent)
+					.end(() => {
+						request(this.app)
+							.get(pathEncoded)
+							.set('Connection', 'close')
+							.expect(expectedContent)
+							.end(done);
+					});
+			});
+
 		});
-
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
-
-		it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
-
-		it('should respond with the contents of the static bundle', function(done) {
-			this.request.expect('/* STATIC BUNDLE (bundles/css) */\n').end(done);
-		});
-
-		it('should ignore URL encoding when checking for static bundles', function(done) {
-			const pathUnencoded = `/bundles/css?modules=${moduleName}^1.0.0`;
-			const pathEncoded = `/bundles/css?modules=${moduleName}%5E1.0.0`;
-			const expectedContent = '/* STATIC BUNDLE (bundles/css) */\n';
-
-			request(this.app)
-				.get(pathUnencoded)
-				.set('Connection', 'close')
-				.expect(expectedContent)
-				.end(() => {
-					request(this.app)
-						.get(pathEncoded)
-						.set('Connection', 'close')
-						.expect(expectedContent)
-						.end(done);
-				});
-		});
-
-	});
+	}
 
 });

--- a/test/integration/bundles-css.test.js
+++ b/test/integration/bundles-css.test.js
@@ -21,7 +21,7 @@ describe('GET /bundles/css', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});

--- a/test/integration/bundles-css.test.js
+++ b/test/integration/bundles-css.test.js
@@ -26,6 +26,7 @@ describe('GET /bundles/css', function() {
 
 	});
 
+	// These tests are not possible to run against a remote server because they require a set of fixture files to exist, which do not exist on our remote servers.
 	if (!process.env.HOST) {
 		describe('when a module is requested that has a static bundle', function() {
 			const moduleName = 'mock-modules/test-static';

--- a/test/integration/bundles-js.test.js
+++ b/test/integration/bundles-js.test.js
@@ -21,50 +21,51 @@ describe('GET /bundles/js', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});
 
-	describe('when a module is requested that has a static bundle', function() {
-		const moduleName = 'mock-modules/test-static';
+	if (!process.env.HOST) {
+		describe('when a module is requested that has a static bundle', function() {
+			const moduleName = 'mock-modules/test-static';
 
-		beforeEach(function() {
-			this.request = request(this.app)
-				.get(`/bundles/js?modules=${moduleName}`)
-				.set('Connection', 'close');
+			beforeEach(function() {
+				this.request = request(this.app)
+					.get(`/bundles/js?modules=${moduleName}`)
+					.set('Connection', 'close');
+			});
+
+			it('should respond with a 200 status', function(done) {
+				this.request.expect(200).end(done);
+			});
+
+			it('should respond with the expected `Content-Type` header', function(done) {
+				this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
+			});
+
+			it('should respond with the contents of the static bundle', function(done) {
+				this.request.expect('/* STATIC BUNDLE (bundles/js) */\n').end(done);
+			});
+
+			it('should ignore URL encoding when checking for static bundles', function(done) {
+				const pathUnencoded = `/bundles/js?modules=${moduleName}^1.0.0`;
+				const pathEncoded = `/bundles/js?modules=${moduleName}%5E1.0.0`;
+				const expectedContent = '/* STATIC BUNDLE (bundles/js) */\n';
+
+				request(this.app)
+					.get(pathUnencoded)
+					.set('Connection', 'close')
+					.expect(expectedContent)
+					.end(() => {
+						request(this.app)
+							.get(pathEncoded)
+							.set('Connection', 'close')
+							.expect(expectedContent)
+							.end(done);
+					});
+			});
+
 		});
-
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
-
-		it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
-
-		it('should respond with the contents of the static bundle', function(done) {
-			this.request.expect('/* STATIC BUNDLE (bundles/js) */\n').end(done);
-		});
-
-		it('should ignore URL encoding when checking for static bundles', function(done) {
-			const pathUnencoded = `/bundles/js?modules=${moduleName}^1.0.0`;
-			const pathEncoded = `/bundles/js?modules=${moduleName}%5E1.0.0`;
-			const expectedContent = '/* STATIC BUNDLE (bundles/js) */\n';
-
-			request(this.app)
-				.get(pathUnencoded)
-				.set('Connection', 'close')
-				.expect(expectedContent)
-				.end(() => {
-					request(this.app)
-						.get(pathEncoded)
-						.set('Connection', 'close')
-						.expect(expectedContent)
-						.end(done);
-				});
-		});
-
-	});
-
+	}
 });

--- a/test/integration/bundles-js.test.js
+++ b/test/integration/bundles-js.test.js
@@ -26,6 +26,7 @@ describe('GET /bundles/js', function() {
 
 	});
 
+	// These tests are not possible to run against a remote server because they require a set of fixture files to exist, which do not exist on our remote servers.
 	if (!process.env.HOST) {
 		describe('when a module is requested that has a static bundle', function() {
 			const moduleName = 'mock-modules/test-static';

--- a/test/integration/bundles-js.test.js
+++ b/test/integration/bundles-js.test.js
@@ -21,7 +21,7 @@ describe('GET /bundles/js', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});

--- a/test/integration/files.test.js
+++ b/test/integration/files.test.js
@@ -21,7 +21,7 @@ describe('GET /files', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/files/${moduleName}/${pathName}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/files/${moduleName}/${pathName}`).end(done);
 		});
 
 	});

--- a/test/integration/files.test.js
+++ b/test/integration/files.test.js
@@ -21,7 +21,7 @@ describe('GET /files', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/files/${moduleName}/${pathName}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/files/${moduleName}/${pathName}`).end(done);
 		});
 
 	});

--- a/test/integration/home.test.js
+++ b/test/integration/home.test.js
@@ -17,7 +17,7 @@ describe('GET /', function() {
 	});
 
 	it('should respond with a v2 `Location` header', function(done) {
-		this.request.expect('Location', `${this.basepath}/v2/`).end(done);
+		this.request.expect('Location', `${this.basepath}v2/`).end(done);
 	});
 
 	it('should respond with HTML', function(done) {

--- a/test/integration/home.test.js
+++ b/test/integration/home.test.js
@@ -17,15 +17,11 @@ describe('GET /', function() {
 	});
 
 	it('should respond with a v2 `Location` header', function(done) {
-		this.request.expect('Location', '/v2/').end(done);
+		this.request.expect('Location', `${this.basepath}/v2/`).end(done);
 	});
 
 	it('should respond with HTML', function(done) {
 		this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
-	});
-
-	it('should respond with the build service documentation', function(done) {
-		this.request.expect('Moved Permanently. Redirecting to /v2/').end(done);
 	});
 
 });

--- a/test/integration/modules.test.js
+++ b/test/integration/modules.test.js
@@ -20,7 +20,7 @@ describe('GET /modules', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/modules/${moduleName}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/modules/${moduleName}`).end(done);
 		});
 
 	});

--- a/test/integration/modules.test.js
+++ b/test/integration/modules.test.js
@@ -20,7 +20,7 @@ describe('GET /modules', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/modules/${moduleName}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/modules/${moduleName}`).end(done);
 		});
 
 	});

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -34,7 +34,7 @@ before(function() {
 		.listen()
 		.then(app => {
 			this.app = app;
-			this.basepath = '';
+			this.basepath = '/';
 		});
 	}
 });

--- a/test/integration/v1-bundles-css.test.js
+++ b/test/integration/v1-bundles-css.test.js
@@ -21,6 +21,7 @@ describe('GET /v1/bundles/css', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
+			// This test is not possible to run against a remote server which is behind a CDN such as Fastly because CDN's remove the Surrogate-Control header
 			if (process.env.HOST) {
 				this.skip();
 			} else {
@@ -36,6 +37,7 @@ describe('GET /v1/bundles/css', function() {
 
 	});
 
+	// These tests are not possible to run against a remote server because they require a set of fixture files to exist, which do not exist on our remote servers.
 	if (!process.env.HOST) {
 		describe('when a module is requested that has a static bundle', function() {
 			const moduleName = 'mock-modules/test-static';

--- a/test/integration/v1-bundles-css.test.js
+++ b/test/integration/v1-bundles-css.test.js
@@ -31,7 +31,7 @@ describe('GET /v1/bundles/css', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});

--- a/test/integration/v1-bundles-css.test.js
+++ b/test/integration/v1-bundles-css.test.js
@@ -21,56 +21,62 @@ describe('GET /v1/bundles/css', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
-			this.request
-				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
-				.end(done);
+			if (process.env.HOST) {
+				this.skip();
+			} else {
+				this.request
+					.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+					.end(done);
+			}
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/bundles/css?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});
 
-	describe('when a module is requested that has a static bundle', function() {
-		const moduleName = 'mock-modules/test-static';
+	if (!process.env.HOST) {
+		describe('when a module is requested that has a static bundle', function() {
+			const moduleName = 'mock-modules/test-static';
 
-		beforeEach(function() {
-			this.request = request(this.app)
-				.get(`/v1/bundles/css?modules=${moduleName}`)
-				.set('Connection', 'close');
+			beforeEach(function() {
+				this.request = request(this.app)
+					.get(`/v1/bundles/css?modules=${moduleName}`)
+					.set('Connection', 'close');
+			});
+
+			it('should respond with a 200 status', function(done) {
+				this.request.expect(200).end(done);
+			});
+
+			it('should respond with the expected `Content-Type` header', function(done) {
+				this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
+			});
+
+			it('should respond with the contents of the static bundle', function(done) {
+				this.request.expect('/* STATIC BUNDLE (v1/bundles/css) */\n').end(done);
+			});
+
+			it('should ignore URL encoding when checking for static bundles', function(done) {
+				const pathUnencoded = `/v1/bundles/css?modules=${moduleName}^1.0.0`;
+				const pathEncoded = `/v1/bundles/css?modules=${moduleName}%5E1.0.0`;
+				const expectedContent = '/* STATIC BUNDLE (v1/bundles/css) */\n';
+
+				request(this.app)
+					.get(pathUnencoded)
+					.set('Connection', 'close')
+					.expect(expectedContent)
+					.end(() => {
+						request(this.app)
+							.get(pathEncoded)
+							.set('Connection', 'close')
+							.expect(expectedContent)
+							.end(done);
+					});
+			});
+
 		});
-
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
-
-		it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
-
-		it('should respond with the contents of the static bundle', function(done) {
-			this.request.expect('/* STATIC BUNDLE (v1/bundles/css) */\n').end(done);
-		});
-
-		it('should ignore URL encoding when checking for static bundles', function(done) {
-			const pathUnencoded = `/v1/bundles/css?modules=${moduleName}^1.0.0`;
-			const pathEncoded = `/v1/bundles/css?modules=${moduleName}%5E1.0.0`;
-			const expectedContent = '/* STATIC BUNDLE (v1/bundles/css) */\n';
-
-			request(this.app)
-				.get(pathUnencoded)
-				.set('Connection', 'close')
-				.expect(expectedContent)
-				.end(() => {
-					request(this.app)
-						.get(pathEncoded)
-						.set('Connection', 'close')
-						.expect(expectedContent)
-						.end(done);
-				});
-		});
-
-	});
+	}
 
 });

--- a/test/integration/v1-bundles-js.test.js
+++ b/test/integration/v1-bundles-js.test.js
@@ -31,7 +31,7 @@ describe('GET /v1/bundles/js', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});

--- a/test/integration/v1-bundles-js.test.js
+++ b/test/integration/v1-bundles-js.test.js
@@ -21,57 +21,61 @@ describe('GET /v1/bundles/js', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
-			this.request
-				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
-				.end(done);
-
+			if (process.env.HOST) {
+				this.skip();
+			} else {
+				this.request
+					.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+					.end(done);
+			}
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/bundles/js?modules=${moduleName}&newerthan=${now}`).end(done);
 		});
 
 	});
 
-	describe('when a module is requested that has a static bundle', function() {
-		const moduleName = 'mock-modules/test-static';
+	if (!process.env.HOST) {
+		describe('when a module is requested that has a static bundle', function() {
+			const moduleName = 'mock-modules/test-static';
 
-		beforeEach(function() {
-			this.request = request(this.app)
-				.get(`/v1/bundles/js?modules=${moduleName}`)
-				.set('Connection', 'close');
+			beforeEach(function() {
+				this.request = request(this.app)
+					.get(`/v1/bundles/js?modules=${moduleName}`)
+					.set('Connection', 'close');
+			});
+
+			it('should respond with a 200 status', function(done) {
+				this.request.expect(200).end(done);
+			});
+
+			it('should respond with the expected `Content-Type` header', function(done) {
+				this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
+			});
+
+			it('should respond with the contents of the static bundle', function(done) {
+				this.request.expect('/* STATIC BUNDLE (v1/bundles/js) */\n').end(done);
+			});
+
+			it('should ignore URL encoding when checking for static bundles', function(done) {
+				const pathUnencoded = `/v1/bundles/js?modules=${moduleName}^1.0.0`;
+				const pathEncoded = `/v1/bundles/js?modules=${moduleName}%5E1.0.0`;
+				const expectedContent = '/* STATIC BUNDLE (v1/bundles/js) */\n';
+
+				request(this.app)
+					.get(pathUnencoded)
+					.set('Connection', 'close')
+					.expect(expectedContent)
+					.end(() => {
+						request(this.app)
+							.get(pathEncoded)
+							.set('Connection', 'close')
+							.expect(expectedContent)
+							.end(done);
+					});
+			});
+
 		});
-
-		it('should respond with a 200 status', function(done) {
-			this.request.expect(200).end(done);
-		});
-
-		it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
-
-		it('should respond with the contents of the static bundle', function(done) {
-			this.request.expect('/* STATIC BUNDLE (v1/bundles/js) */\n').end(done);
-		});
-
-		it('should ignore URL encoding when checking for static bundles', function(done) {
-			const pathUnencoded = `/v1/bundles/js?modules=${moduleName}^1.0.0`;
-			const pathEncoded = `/v1/bundles/js?modules=${moduleName}%5E1.0.0`;
-			const expectedContent = '/* STATIC BUNDLE (v1/bundles/js) */\n';
-
-			request(this.app)
-				.get(pathUnencoded)
-				.set('Connection', 'close')
-				.expect(expectedContent)
-				.end(() => {
-					request(this.app)
-						.get(pathEncoded)
-						.set('Connection', 'close')
-						.expect(expectedContent)
-						.end(done);
-				});
-		});
-
-	});
-
+	}
 });

--- a/test/integration/v1-bundles-js.test.js
+++ b/test/integration/v1-bundles-js.test.js
@@ -21,6 +21,7 @@ describe('GET /v1/bundles/js', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
+			// This test is not possible to run against a remote server which is behind a CDN such as Fastly because CDN's remove the Surrogate-Control header
 			if (process.env.HOST) {
 				this.skip();
 			} else {
@@ -36,6 +37,7 @@ describe('GET /v1/bundles/js', function() {
 
 	});
 
+	// These tests are not possible to run against a remote server because they require a set of fixture files to exist, which do not exist on our remote servers.
 	if (!process.env.HOST) {
 		describe('when a module is requested that has a static bundle', function() {
 			const moduleName = 'mock-modules/test-static';

--- a/test/integration/v1-files.test.js
+++ b/test/integration/v1-files.test.js
@@ -21,6 +21,7 @@ describe('GET /v1/files', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
+			// This test is not possible to run against a remote server which is behind a CDN such as Fastly because CDN's remove the Surrogate-Control header
 			if (process.env.HOST) {
 				this.skip();
 			} else {

--- a/test/integration/v1-files.test.js
+++ b/test/integration/v1-files.test.js
@@ -21,13 +21,17 @@ describe('GET /v1/files', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
-			this.request
-				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
-				.end(done);
+			if (process.env.HOST) {
+				this.skip();
+			} else {
+				this.request
+					.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+					.end(done);
+			}
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/files/${moduleName}/${pathName}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/files/${moduleName}/${pathName}`).end(done);
 		});
 
 	});

--- a/test/integration/v1-files.test.js
+++ b/test/integration/v1-files.test.js
@@ -31,7 +31,7 @@ describe('GET /v1/files', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/files/${moduleName}/${pathName}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/files/${moduleName}/${pathName}`).end(done);
 		});
 
 	});

--- a/test/integration/v1-modules.test.js
+++ b/test/integration/v1-modules.test.js
@@ -30,7 +30,7 @@ describe('GET /v1/modules', function() {
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `${this.basepath}/v2/modules/${moduleName}`).end(done);
+			this.request.expect('Location', `${this.basepath}v2/modules/${moduleName}`).end(done);
 		});
 
 	});

--- a/test/integration/v1-modules.test.js
+++ b/test/integration/v1-modules.test.js
@@ -20,13 +20,17 @@ describe('GET /v1/modules', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
-			this.request
-				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
-				.end(done);
+			if (process.env.HOST) {
+				this.skip();
+			} else {
+				this.request
+					.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+					.end(done);
+			}
 		});
 
 		it('should respond with a v2 `Location` header', function(done) {
-			this.request.expect('Location', `/v2/modules/${moduleName}`).end(done);
+			this.request.expect('Location', `${this.basepath}/v2/modules/${moduleName}`).end(done);
 		});
 
 	});

--- a/test/integration/v1-modules.test.js
+++ b/test/integration/v1-modules.test.js
@@ -20,6 +20,7 @@ describe('GET /v1/modules', function() {
 		});
 
 		it('should response with a year long surrogate cache control header', function(done) {
+			// This test is not possible to run against a remote server which is behind a CDN such as Fastly because CDN's remove the Surrogate-Control header
 			if (process.env.HOST) {
 				this.skip();
 			} else {

--- a/test/integration/v1.test.js
+++ b/test/integration/v1.test.js
@@ -17,17 +17,17 @@ describe('GET /v1', function() {
 	});
 
 	it('should response with a year long surrogate cache control header', function(done) {
-		this.request
-			.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
-			.end(done);
+		if (process.env.HOST) {
+			this.skip();
+		} else {
+			this.request
+				.expect('Surrogate-Control', 'public, max-age=31536000, stale-while-revalidate=31536000, stale-if-error=31536000')
+				.end(done);
+		}
 	});
 
 	it('should respond with HTML', function(done) {
 		this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
-	});
-
-	it('should respond with the build service documentation', function(done) {
-			this.request.expect('Moved Permanently. Redirecting to /v2/').end(done);
 	});
 
 });

--- a/test/integration/v1.test.js
+++ b/test/integration/v1.test.js
@@ -17,6 +17,7 @@ describe('GET /v1', function() {
 	});
 
 	it('should response with a year long surrogate cache control header', function(done) {
+			// This test is not possible to run against a remote server which is behind a CDN such as Fastly because CDN's remove the Surrogate-Control header
 		if (process.env.HOST) {
 			this.skip();
 		} else {


### PR DESCRIPTION
Closes https://github.com/Financial-Times/origami-build-service/issues/248

This change makes the integration tests also run against the development and staging heroku applications, which should give us greater confidence in the code before we promote it to production.