### PR TITLE
bugfix: set NODE_ENV to the string "production" and not the JS identifier production

### DIFF
--- a/lib/middleware/v3/bundleJavascript.js
+++ b/lib/middleware/v3/bundleJavascript.js
@@ -21,7 +21,7 @@ async function bundleJavascript(location) {
         splitting: false,
         platform: 'browser',
         define: {
-            'process.env.NODE_ENV': 'production'
+            'process.env.NODE_ENV': '"production"'
         },
         entryPoints: [path.join(location, 'index.js')]
     });
@@ -42,7 +42,7 @@ async function bundleJavascript(location) {
         splitting: false,
         platform: 'browser',
         define: {
-            'process.env.NODE_ENV': 'production'
+            'process.env.NODE_ENV': '"production"'
         },
         stdin: {
             contents: compiledBundle.code


### PR DESCRIPTION
ESBuild reported this as a warning and fixed the issue in the bundles it generated. It's better to fix the issue in our code to stop the warning being emitted.