### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -991,9 +991,9 @@
       }
     },
     "@financial-times/health-check": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/health-check/-/health-check-2.1.6.tgz",
-      "integrity": "sha512-cqb6HjTyi/VLIP7C5oM+FyRn/YuDpCjGV0zKzCyhUmLtn08BzO7wCbwIqlO/EzAeGIrgnhv81qzj49wEcseLHA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@financial-times/health-check/-/health-check-2.1.7.tgz",
+      "integrity": "sha512-Fz5hep9TvOl53acqsiAfOajibfwnzSJERFoudIEdPepzacj9s8IaablFp/u4bXFZjTXaHXiwB29o04oVUFQlmw==",
       "requires": {
         "axios": "^0.21.1",
         "disk-space": "^1.1.0",


### PR DESCRIPTION
### Updated (252)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@financial-times/health-check](https://npm.im/@financial-times/health-check) | `2.1.1` → `2.1.7` | [github](https://github.com/Financial-Times/node-health-check) | - |
| [@npmcli/arborist](https://npm.im/@npmcli/arborist) | `2.0.0` → `2.0.0` | [github](https://github.com/npm/arborist) | - |
| [@npmcli/ci-detect](https://npm.im/@npmcli/ci-detect) | `1.3.0` → `1.3.0` | [github](https://github.com/npm/ci-detect) | - |
| [@npmcli/config](https://npm.im/@npmcli/config) | `1.2.4` → `1.2.4` | [github](https://github.com/npm/config) | - |
| [@npmcli/git](https://npm.im/@npmcli/git) | `2.0.4` → `2.0.4` | [github](https://github.com/npm/git) | - |
| [@npmcli/installed-package-contents](https://npm.im/@npmcli/installed-package-contents) | `1.0.5` → `1.0.5` | [github](https://github.com/npm/installed-package-contents) | - |
| [@npmcli/map-workspaces](https://npm.im/@npmcli/map-workspaces) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/map-workspaces) | - |
| [@npmcli/metavuln-calculator](https://npm.im/@npmcli/metavuln-calculator) | `1.0.0` → `1.0.0` | [github](https://github.com/npm/metavuln-calculator) | - |
| [@npmcli/move-file](https://npm.im/@npmcli/move-file) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/move-file) | - |
| [@npmcli/name-from-folder](https://npm.im/@npmcli/name-from-folder) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/name-from-folder) | - |
| [@npmcli/node-gyp](https://npm.im/@npmcli/node-gyp) | `1.0.1` → `1.0.1` | - | - |
| [@npmcli/promise-spawn](https://npm.im/@npmcli/promise-spawn) | `1.3.2` → `1.3.2` | [github](https://github.com/npm/promise-spawn) | - |
| [@npmcli/run-script](https://npm.im/@npmcli/run-script) | `1.8.1` → `1.8.1` | [github](https://github.com/npm/run-script) | - |
| [@tootallnate/once](https://npm.im/@tootallnate/once) | `1.1.2` → `1.1.2` | [github](https://github.com/TooTallNate/once) | - |
| [abbrev](https://npm.im/abbrev) | `1.1.1` → `1.1.1` | [github](https://github.com/isaacs/abbrev-js) | - |
| [agent-base](https://npm.im/agent-base) | `6.0.2` → `6.0.2` | [github](https://github.com/TooTallNate/node-agent-base) | - |
| [agentkeepalive](https://npm.im/agentkeepalive) | `4.1.3` → `4.1.3` | [github](https://github.com/node-modules/agentkeepalive) | - |
| [aggregate-error](https://npm.im/aggregate-error) | `3.1.0` → `3.1.0` | [github](https://github.com/sindresorhus/aggregate-error) | - |
| [ajv](https://npm.im/ajv) | `6.12.6` → `6.12.6` | [github](https://github.com/ajv-validator/ajv) | - |
| [ansi-regex](https://npm.im/ansi-regex) | `2.1.1` → `2.1.1` | [github](https://github.com/chalk/ansi-regex) | - |
| [ansi-regex](https://npm.im/ansi-regex) | `3.0.0` → `3.0.0` | [github](https://github.com/chalk/ansi-regex) | - |
| [ansi-regex](https://npm.im/ansi-regex) | `5.0.0` → `5.0.0` | [github](https://github.com/chalk/ansi-regex) | - |
| [ansi-styles](https://npm.im/ansi-styles) | `4.3.0` → `4.3.0` | [github](https://github.com/chalk/ansi-styles) | - |
| [ansicolors](https://npm.im/ansicolors) | `0.3.2` → `0.3.2` | [github](https://github.com/thlorenz/ansicolors) | - |
| [ansistyles](https://npm.im/ansistyles) | `0.1.3` → `0.1.3` | [github](https://github.com/thlorenz/ansistyles) | - |
| [aproba](https://npm.im/aproba) | `1.2.0` → `1.2.0` | [github](https://github.com/iarna/aproba) | - |
| [aproba](https://npm.im/aproba) | `2.0.0` → `2.0.0` | [github](https://github.com/iarna/aproba) | - |
| [archy](https://npm.im/archy) | `1.0.0` → `1.0.0` | [github](https://github.com/substack/node-archy) | - |
| [are-we-there-yet](https://npm.im/are-we-there-yet) | `1.1.5` → `1.1.5` | [github](https://github.com/iarna/are-we-there-yet) | - |
| [asap](https://npm.im/asap) | `2.0.6` → `2.0.6` | [github](https://github.com/kriskowal/asap) | - |
| [asn1](https://npm.im/asn1) | `0.2.4` → `0.2.4` | [github](https://github.com/joyent/node-asn1) | - |
| [assert-plus](https://npm.im/assert-plus) | `1.0.0` → `1.0.0` | [github](https://github.com/mcavage/node-assert-plus) | - |
| [asynckit](https://npm.im/asynckit) | `0.4.0` → `0.4.0` | [github](https://github.com/alexindigo/asynckit) | - |
| [aws-sign2](https://npm.im/aws-sign2) | `0.7.0` → `0.7.0` | [github](https://github.com/mikeal/aws-sign) | - |
| [aws4](https://npm.im/aws4) | `1.11.0` → `1.11.0` | [github](https://github.com/mhart/aws4) | - |
| [balanced-match](https://npm.im/balanced-match) | `1.0.0` → `1.0.0` | [github](https://github.com/juliangruber/balanced-match) | - |
| [bcrypt-pbkdf](https://npm.im/bcrypt-pbkdf) | `1.0.2` → `1.0.2` | [github](https://github.com/joyent/node-bcrypt-pbkdf) | - |
| [bin-links](https://npm.im/bin-links) | `2.2.1` → `2.2.1` | [github](https://github.com/npm/bin-links) | - |
| [brace-expansion](https://npm.im/brace-expansion) | `1.1.11` → `1.1.11` | [github](https://github.com/juliangruber/brace-expansion) | - |
| [builtins](https://npm.im/builtins) | `1.0.3` → `1.0.3` | [github](https://github.com/juliangruber/builtins) | - |
| [byte-size](https://npm.im/byte-size) | `7.0.0` → `7.0.0` | [github](https://github.com/75lb/byte-size) | - |
| [cacache](https://npm.im/cacache) | `15.0.5` → `15.0.5` | [github](https://github.com/npm/cacache) | - |
| [caseless](https://npm.im/caseless) | `0.12.0` → `0.12.0` | [github](https://github.com/mikeal/caseless) | - |
| [chalk](https://npm.im/chalk) | `4.1.0` → `4.1.0` | [github](https://github.com/chalk/chalk) | - |
| [chownr](https://npm.im/chownr) | `2.0.0` → `2.0.0` | [github](https://github.com/isaacs/chownr) | - |
| [cidr-regex](https://npm.im/cidr-regex) | `3.1.1` → `3.1.1` | [github](https://github.com/silverwind/cidr-regex) | - |
| [clean-stack](https://npm.im/clean-stack) | `2.2.0` → `2.2.0` | [github](https://github.com/sindresorhus/clean-stack) | - |
| [cli-columns](https://npm.im/cli-columns) | `3.1.2` → `3.1.2` | [github](https://github.com/shannonmoeller/cli-columns) | - |
| [cli-table3](https://npm.im/cli-table3) | `0.6.0` → `0.6.0` | [github](https://github.com/cli-table/cli-table3) | - |
| [clone](https://npm.im/clone) | `1.0.4` → `1.0.4` | [github](https://github.com/pvorb/node-clone) | - |
| [cmd-shim](https://npm.im/cmd-shim) | `4.0.2` → `4.0.2` | [github](https://github.com/npm/cmd-shim) | - |
| [code-point-at](https://npm.im/code-point-at) | `1.1.0` → `1.1.0` | [github](https://github.com/sindresorhus/code-point-at) | - |
| [color-convert](https://npm.im/color-convert) | `2.0.1` → `2.0.1` | [github](https://github.com/Qix-/color-convert) | - |
| [color-name](https://npm.im/color-name) | `1.1.4` → `1.1.4` | [github](https://github.com/colorjs/color-name) | - |
| [colors](https://npm.im/colors) | `1.4.0` → `1.4.0` | [github](https://github.com/Marak/colors.js) | - |
| [columnify](https://npm.im/columnify) | `1.5.4` → `1.5.4` | [github](https://github.com/timoxley/columnify) | - |
| [combined-stream](https://npm.im/combined-stream) | `1.0.8` → `1.0.8` | [github](https://github.com/felixge/node-combined-stream) | - |
| [common-ancestor-path](https://npm.im/common-ancestor-path) | `1.0.1` → `1.0.1` | [github](https://github.com/isaacs/common-ancestor-path) | - |
| [concat-map](https://npm.im/concat-map) | `0.0.1` → `0.0.1` | [github](https://github.com/substack/node-concat-map) | - |
| [console-control-strings](https://npm.im/console-control-strings) | `1.1.0` → `1.1.0` | [github](https://github.com/iarna/console-control-strings) | - |
| [core-util-is](https://npm.im/core-util-is) | `1.0.2` → `1.0.2` | [github](https://github.com/isaacs/core-util-is) | - |
| [dashdash](https://npm.im/dashdash) | `1.14.1` → `1.14.1` | [github](https://github.com/trentm/node-dashdash) | - |
| [debug](https://npm.im/debug) | `4.3.1` → `4.3.1` | [github](https://github.com/visionmedia/debug) | - |
| [debuglog](https://npm.im/debuglog) | `1.0.1` → `1.0.1` | [github](https://github.com/sam-github/node-debuglog) | - |
| [defaults](https://npm.im/defaults) | `1.0.3` → `1.0.3` | [github](https://github.com/tmpvar/defaults) | - |
| [delayed-stream](https://npm.im/delayed-stream) | `1.0.0` → `1.0.0` | [github](https://github.com/felixge/node-delayed-stream) | - |
| [delegates](https://npm.im/delegates) | `1.0.0` → `1.0.0` | [github](https://github.com/visionmedia/node-delegates) | - |
| [depd](https://npm.im/depd) | `1.1.2` → `1.1.2` | [github](https://github.com/dougwilson/nodejs-depd) | - |
| [dezalgo](https://npm.im/dezalgo) | `1.0.3` → `1.0.3` | [github](https://github.com/npm/dezalgo) | - |
| [ecc-jsbn](https://npm.im/ecc-jsbn) | `0.1.2` → `0.1.2` | [github](https://github.com/quartzjer/ecc-jsbn) | - |
| [editor](https://npm.im/editor) | `1.0.0` → `1.0.0` | [github](https://github.com/substack/node-editor) | - |
| [emoji-regex](https://npm.im/emoji-regex) | `8.0.0` → `8.0.0` | [github](https://github.com/mathiasbynens/emoji-regex) | - |
| [encoding](https://npm.im/encoding) | `0.1.13` → `0.1.13` | [github](https://github.com/andris9/encoding) | - |
| [env-paths](https://npm.im/env-paths) | `2.2.0` → `2.2.0` | [github](https://github.com/sindresorhus/env-paths) | - |
| [err-code](https://npm.im/err-code) | `1.1.2` → `1.1.2` | [github](https://github.com/IndigoUnited/js-err-code) | - |
| [extend](https://npm.im/extend) | `3.0.2` → `3.0.2` | [github](https://github.com/justmoon/node-extend) | - |
| [extsprintf](https://npm.im/extsprintf) | `1.3.0` → `1.3.0` | [github](https://github.com/davepacheco/node-extsprintf) | - |
| [fast-deep-equal](https://npm.im/fast-deep-equal) | `3.1.3` → `3.1.3` | [github](https://github.com/epoberezkin/fast-deep-equal) | - |
| [fast-json-stable-stringify](https://npm.im/fast-json-stable-stringify) | `2.1.0` → `2.1.0` | [github](https://github.com/epoberezkin/fast-json-stable-stringify) | - |
| [forever-agent](https://npm.im/forever-agent) | `0.6.1` → `0.6.1` | [github](https://github.com/mikeal/forever-agent) | - |
| [form-data](https://npm.im/form-data) | `2.3.3` → `2.3.3` | [github](https://github.com/form-data/form-data) | - |
| [fs-minipass](https://npm.im/fs-minipass) | `2.1.0` → `2.1.0` | [github](https://github.com/npm/fs-minipass) | - |
| [fs.realpath](https://npm.im/fs.realpath) | `1.0.0` → `1.0.0` | [github](https://github.com/isaacs/fs.realpath) | - |
| [function-bind](https://npm.im/function-bind) | `1.1.1` → `1.1.1` | [github](https://github.com/Raynos/function-bind) | - |
| [gauge](https://npm.im/gauge) | `2.7.4` → `2.7.4` | [github](https://github.com/iarna/gauge) | - |
| [getpass](https://npm.im/getpass) | `0.1.7` → `0.1.7` | [github](https://github.com/arekinath/node-getpass) | - |
| [glob](https://npm.im/glob) | `7.1.6` → `7.1.6` | [github](https://github.com/isaacs/node-glob) | - |
| [graceful-fs](https://npm.im/graceful-fs) | `4.2.4` → `4.2.4` | [github](https://github.com/isaacs/node-graceful-fs) | - |
| [har-schema](https://npm.im/har-schema) | `2.0.0` → `2.0.0` | [github](https://github.com/ahmadnassri/har-schema) | - |
| [har-validator](https://npm.im/har-validator) | `5.1.5` → `5.1.5` | [github](https://github.com/ahmadnassri/node-har-validator) | - |
| [has](https://npm.im/has) | `1.0.3` → `1.0.3` | [github](https://github.com/tarruda/has) | - |
| [has-flag](https://npm.im/has-flag) | `4.0.0` → `4.0.0` | [github](https://github.com/sindresorhus/has-flag) | - |
| [has-unicode](https://npm.im/has-unicode) | `2.0.1` → `2.0.1` | [github](https://github.com/iarna/has-unicode) | - |
| [hosted-git-info](https://npm.im/hosted-git-info) | `3.0.7` → `3.0.7` | [github](https://github.com/npm/hosted-git-info) | - |
| [http-cache-semantics](https://npm.im/http-cache-semantics) | `4.1.0` → `4.1.0` | [github](https://github.com/kornelski/http-cache-semantics) | - |
| [http-proxy-agent](https://npm.im/http-proxy-agent) | `4.0.1` → `4.0.1` | [github](https://github.com/TooTallNate/node-http-proxy-agent) | - |
| [http-signature](https://npm.im/http-signature) | `1.2.0` → `1.2.0` | [github](https://github.com/joyent/node-http-signature) | - |
| [https-proxy-agent](https://npm.im/https-proxy-agent) | `5.0.0` → `5.0.0` | [github](https://github.com/TooTallNate/node-https-proxy-agent) | - |
| [humanize-ms](https://npm.im/humanize-ms) | `1.2.1` → `1.2.1` | [github](https://github.com/node-modules/humanize-ms) | - |
| [iconv-lite](https://npm.im/iconv-lite) | `0.6.2` → `0.6.2` | [github](https://github.com/ashtuchkin/iconv-lite) | - |
| [ignore-walk](https://npm.im/ignore-walk) | `3.0.3` → `3.0.3` | [github](https://github.com/isaacs/ignore-walk) | - |
| [imurmurhash](https://npm.im/imurmurhash) | `0.1.4` → `0.1.4` | [github](https://github.com/jensyt/imurmurhash-js) | - |
| [indent-string](https://npm.im/indent-string) | `4.0.0` → `4.0.0` | [github](https://github.com/sindresorhus/indent-string) | - |
| [infer-owner](https://npm.im/infer-owner) | `1.0.4` → `1.0.4` | [github](https://github.com/npm/infer-owner) | - |
| [inflight](https://npm.im/inflight) | `1.0.6` → `1.0.6` | [github](https://github.com/npm/inflight) | - |
| [inherits](https://npm.im/inherits) | `2.0.4` → `2.0.4` | [github](https://github.com/isaacs/inherits) | - |
| [ini](https://npm.im/ini) | `1.3.6` → `1.3.6` | [github](https://github.com/isaacs/ini) | - |
| [init-package-json](https://npm.im/init-package-json) | `2.0.1` → `2.0.1` | [github](https://github.com/npm/init-package-json) | - |
| [ip](https://npm.im/ip) | `1.1.5` → `1.1.5` | [github](https://github.com/indutny/node-ip) | - |
| [ip-regex](https://npm.im/ip-regex) | `4.2.0` → `4.2.0` | [github](https://github.com/sindresorhus/ip-regex) | - |
| [is-cidr](https://npm.im/is-cidr) | `4.0.2` → `4.0.2` | [github](https://github.com/silverwind/is-cidr) | - |
| [is-core-module](https://npm.im/is-core-module) | `2.2.0` → `2.2.0` | [github](https://github.com/inspect-js/is-core-module) | - |
| [is-fullwidth-code-point](https://npm.im/is-fullwidth-code-point) | `1.0.0` → `1.0.0` | [github](https://github.com/sindresorhus/is-fullwidth-code-point) | - |
| [is-fullwidth-code-point](https://npm.im/is-fullwidth-code-point) | `2.0.0` → `2.0.0` | [github](https://github.com/sindresorhus/is-fullwidth-code-point) | - |
| [is-fullwidth-code-point](https://npm.im/is-fullwidth-code-point) | `3.0.0` → `3.0.0` | [github](https://github.com/sindresorhus/is-fullwidth-code-point) | - |
| [is-lambda](https://npm.im/is-lambda) | `1.0.1` → `1.0.1` | [github](https://github.com/watson/is-lambda) | - |
| [is-typedarray](https://npm.im/is-typedarray) | `1.0.0` → `1.0.0` | [github](https://github.com/hughsk/is-typedarray) | - |
| [isarray](https://npm.im/isarray) | `1.0.0` → `1.0.0` | [github](https://github.com/juliangruber/isarray) | - |
| [isexe](https://npm.im/isexe) | `2.0.0` → `2.0.0` | [github](https://github.com/isaacs/isexe) | - |
| [isstream](https://npm.im/isstream) | `0.1.2` → `0.1.2` | [github](https://github.com/rvagg/isstream) | - |
| [jsbn](https://npm.im/jsbn) | `0.1.1` → `0.1.1` | [github](https://github.com/andyperlitch/jsbn) | - |
| [json-parse-even-better-errors](https://npm.im/json-parse-even-better-errors) | `2.3.1` → `2.3.1` | [github](https://github.com/npm/json-parse-even-better-errors) | - |
| [json-schema](https://npm.im/json-schema) | `0.2.3` → `0.2.3` | [github](https://github.com/kriszyp/json-schema) | - |
| [json-schema-traverse](https://npm.im/json-schema-traverse) | `0.4.1` → `0.4.1` | [github](https://github.com/epoberezkin/json-schema-traverse) | - |
| [json-stringify-nice](https://npm.im/json-stringify-nice) | `1.1.1` → `1.1.1` | [github](https://github.com/isaacs/json-stringify-nice) | - |
| [json-stringify-safe](https://npm.im/json-stringify-safe) | `5.0.1` → `5.0.1` | [github](https://github.com/isaacs/json-stringify-safe) | - |
| [jsonparse](https://npm.im/jsonparse) | `1.3.1` → `1.3.1` | [github](https://github.com/creationix/jsonparse) | - |
| [jsprim](https://npm.im/jsprim) | `1.4.1` → `1.4.1` | [github](https://github.com/joyent/node-jsprim) | - |
| [just-diff](https://npm.im/just-diff) | `3.0.2` → `3.0.2` | [github](https://github.com/angus-c/just) | - |
| [just-diff-apply](https://npm.im/just-diff-apply) | `3.0.0` → `3.0.0` | [github](https://github.com/angus-c/just) | - |
| [leven](https://npm.im/leven) | `3.1.0` → `3.1.0` | [github](https://github.com/sindresorhus/leven) | - |
| [libnpmaccess](https://npm.im/libnpmaccess) | `4.0.1` → `4.0.1` | [github](https://github.com/npm/libnpmaccess) | - |
| [libnpmfund](https://npm.im/libnpmfund) | `1.0.2` → `1.0.2` | [github](https://github.com/npm/libnpmfund) | - |
| [libnpmhook](https://npm.im/libnpmhook) | `6.0.1` → `6.0.1` | [github](https://github.com/npm/libnpmhook) | - |
| [libnpmorg](https://npm.im/libnpmorg) | `2.0.1` → `2.0.1` | [github](https://github.com/npm/libnpmorg) | - |
| [libnpmpack](https://npm.im/libnpmpack) | `2.0.0` → `2.0.0` | [github](https://github.com/npm/libnpmpack) | - |
| [libnpmpublish](https://npm.im/libnpmpublish) | `4.0.0` → `4.0.0` | [github](https://github.com/npm/libnpmpublish) | - |
| [libnpmsearch](https://npm.im/libnpmsearch) | `3.1.0` → `3.1.0` | [github](https://github.com/npm/libnpmsearch) | - |
| [libnpmteam](https://npm.im/libnpmteam) | `2.0.2` → `2.0.2` | [github](https://github.com/npm/libnpmteam) | - |
| [libnpmversion](https://npm.im/libnpmversion) | `1.0.7` → `1.0.7` | [github](https://github.com/npm/libnpmversion) | - |
| [lru-cache](https://npm.im/lru-cache) | `6.0.0` → `6.0.0` | [github](https://github.com/isaacs/node-lru-cache) | - |
| [make-fetch-happen](https://npm.im/make-fetch-happen) | `8.0.12` → `8.0.12` | [github](https://github.com/npm/make-fetch-happen) | - |
| [mime-db](https://npm.im/mime-db) | `1.44.0` → `1.44.0` | [github](https://github.com/jshttp/mime-db) | - |
| [mime-types](https://npm.im/mime-types) | `2.1.27` → `2.1.27` | [github](https://github.com/jshttp/mime-types) | - |
| [minimatch](https://npm.im/minimatch) | `3.0.4` → `3.0.4` | [github](https://github.com/isaacs/minimatch) | - |
| [minipass](https://npm.im/minipass) | `3.1.3` → `3.1.3` | [github](https://github.com/isaacs/minipass) | - |
| [minipass-collect](https://npm.im/minipass-collect) | `1.0.2` → `1.0.2` | - | - |
| [minipass-fetch](https://npm.im/minipass-fetch) | `1.3.2` → `1.3.2` | [github](https://github.com/npm/minipass-fetch) | - |
| [minipass-flush](https://npm.im/minipass-flush) | `1.0.5` → `1.0.5` | [github](https://github.com/isaacs/minipass-flush) | - |
| [minipass-json-stream](https://npm.im/minipass-json-stream) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/minipass-json-stream) | - |
| [minipass-pipeline](https://npm.im/minipass-pipeline) | `1.2.4` → `1.2.4` | - | - |
| [minipass-sized](https://npm.im/minipass-sized) | `1.0.3` → `1.0.3` | [github](https://github.com/isaacs/minipass-sized) | - |
| [minizlib](https://npm.im/minizlib) | `2.1.2` → `2.1.2` | [github](https://github.com/isaacs/minizlib) | - |
| [mkdirp](https://npm.im/mkdirp) | `1.0.4` → `1.0.4` | [github](https://github.com/isaacs/node-mkdirp) | - |
| [mkdirp-infer-owner](https://npm.im/mkdirp-infer-owner) | `2.0.0` → `2.0.0` | [github](https://github.com/isaacs/mkdirp-infer-owner) | - |
| [ms](https://npm.im/ms) | `2.1.2` → `2.1.2` | [github](https://github.com/vercel/ms) | - |
| [ms](https://npm.im/ms) | `2.1.3` → `2.1.3` | [github](https://github.com/vercel/ms) | - |
| [mute-stream](https://npm.im/mute-stream) | `0.0.8` → `0.0.8` | [github](https://github.com/isaacs/mute-stream) | - |
| [node-gyp](https://npm.im/node-gyp) | `7.1.2` → `7.1.2` | [github](https://github.com/nodejs/node-gyp) | - |
| [nopt](https://npm.im/nopt) | `5.0.0` → `5.0.0` | [github](https://github.com/npm/nopt) | - |
| [normalize-package-data](https://npm.im/normalize-package-data) | `3.0.0` → `3.0.0` | [github](https://github.com/npm/normalize-package-data) | - |
| [npm-audit-report](https://npm.im/npm-audit-report) | `2.1.4` → `2.1.4` | [github](https://github.com/npm/npm-audit-report) | - |
| [npm-bundled](https://npm.im/npm-bundled) | `1.1.1` → `1.1.1` | [github](https://github.com/npm/npm-bundled) | - |
| [npm-install-checks](https://npm.im/npm-install-checks) | `4.0.0` → `4.0.0` | [github](https://github.com/npm/npm-install-checks) | - |
| [npm-normalize-package-bin](https://npm.im/npm-normalize-package-bin) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/npm-normalize-package-bin) | - |
| [npm-package-arg](https://npm.im/npm-package-arg) | `8.1.0` → `8.1.0` | [github](https://github.com/npm/npm-package-arg) | - |
| [npm-packlist](https://npm.im/npm-packlist) | `2.1.4` → `2.1.4` | [github](https://github.com/npm/npm-packlist) | - |
| [npm-pick-manifest](https://npm.im/npm-pick-manifest) | `6.1.0` → `6.1.0` | [github](https://github.com/npm/npm-pick-manifest) | - |
| [npm-profile](https://npm.im/npm-profile) | `5.0.2` → `5.0.2` | [github](https://github.com/npm/npm-profile) | - |
| [npm-registry-fetch](https://npm.im/npm-registry-fetch) | `9.0.0` → `9.0.0` | [github](https://github.com/npm/npm-registry-fetch) | - |
| [npm-user-validate](https://npm.im/npm-user-validate) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/npm-user-validate) | - |
| [npmlog](https://npm.im/npmlog) | `4.1.2` → `4.1.2` | [github](https://github.com/npm/npmlog) | - |
| [number-is-nan](https://npm.im/number-is-nan) | `1.0.1` → `1.0.1` | [github](https://github.com/sindresorhus/number-is-nan) | - |
| [oauth-sign](https://npm.im/oauth-sign) | `0.9.0` → `0.9.0` | [github](https://github.com/mikeal/oauth-sign) | - |
| [object-assign](https://npm.im/object-assign) | `4.1.1` → `4.1.1` | [github](https://github.com/sindresorhus/object-assign) | - |
| [once](https://npm.im/once) | `1.4.0` → `1.4.0` | [github](https://github.com/isaacs/once) | - |
| [opener](https://npm.im/opener) | `1.5.2` → `1.5.2` | [github](https://github.com/domenic/opener) | - |
| [p-map](https://npm.im/p-map) | `4.0.0` → `4.0.0` | [github](https://github.com/sindresorhus/p-map) | - |
| [pacote](https://npm.im/pacote) | `11.1.13` → `11.1.13` | [github](https://github.com/npm/pacote) | - |
| [parse-conflict-json](https://npm.im/parse-conflict-json) | `1.1.1` → `1.1.1` | [github](https://github.com/npm/parse-conflict-json) | - |
| [path-is-absolute](https://npm.im/path-is-absolute) | `1.0.1` → `1.0.1` | [github](https://github.com/sindresorhus/path-is-absolute) | - |
| [path-parse](https://npm.im/path-parse) | `1.0.6` → `1.0.6` | [github](https://github.com/jbgutierrez/path-parse) | - |
| [performance-now](https://npm.im/performance-now) | `2.1.0` → `2.1.0` | [github](https://github.com/braveg1rl/performance-now) | - |
| [process-nextick-args](https://npm.im/process-nextick-args) | `2.0.1` → `2.0.1` | [github](https://github.com/calvinmetcalf/process-nextick-args) | - |
| [promise-all-reject-late](https://npm.im/promise-all-reject-late) | `1.0.1` → `1.0.1` | - | - |
| [promise-call-limit](https://npm.im/promise-call-limit) | `1.0.1` → `1.0.1` | [github](https://github.com/isaacs/promise-call-limit) | - |
| [promise-inflight](https://npm.im/promise-inflight) | `1.0.1` → `1.0.1` | [github](https://github.com/iarna/promise-inflight) | - |
| [promise-retry](https://npm.im/promise-retry) | `1.1.1` → `1.1.1` | [github](https://github.com/IndigoUnited/node-promise-retry) | - |
| [promzard](https://npm.im/promzard) | `0.3.0` → `0.3.0` | [github](https://github.com/isaacs/promzard) | - |
| [psl](https://npm.im/psl) | `1.8.0` → `1.8.0` | [github](https://github.com/lupomontero/psl) | - |
| [puka](https://npm.im/puka) | `1.0.1` → `1.0.1` | [gitlab](https://gitlab.com/rhendric/puka) | - |
| [punycode](https://npm.im/punycode) | `2.1.1` → `2.1.1` | [github](https://github.com/bestiejs/punycode.js) | - |
| [qrcode-terminal](https://npm.im/qrcode-terminal) | `0.12.0` → `0.12.0` | [github](https://github.com/gtanner/qrcode-terminal) | - |
| [qs](https://npm.im/qs) | `6.5.2` → `6.5.2` | [github](https://github.com/ljharb/qs) | - |
| [read](https://npm.im/read) | `1.0.7` → `1.0.7` | [github](https://github.com/isaacs/read) | - |
| [read-cmd-shim](https://npm.im/read-cmd-shim) | `2.0.0` → `2.0.0` | [github](https://github.com/npm/read-cmd-shim) | - |
| [read-package-json](https://npm.im/read-package-json) | `3.0.0` → `3.0.0` | [github](https://github.com/npm/read-package-json) | - |
| [read-package-json-fast](https://npm.im/read-package-json-fast) | `1.2.1` → `1.2.1` | [github](https://github.com/npm/read-package-json-fast) | - |
| [readable-stream](https://npm.im/readable-stream) | `2.3.7` → `2.3.7` | [github](https://github.com/nodejs/readable-stream) | - |
| [readdir-scoped-modules](https://npm.im/readdir-scoped-modules) | `1.1.0` → `1.1.0` | [github](https://github.com/npm/readdir-scoped-modules) | - |
| [request](https://npm.im/request) | `2.88.2` → `2.88.2` | [github](https://github.com/request/request) | - |
| [resolve](https://npm.im/resolve) | `1.19.0` → `1.19.0` | [github](https://github.com/browserify/resolve) | - |
| [retry](https://npm.im/retry) | `0.10.1` → `0.10.1` | [github](https://github.com/tim-kos/node-retry) | - |
| [rimraf](https://npm.im/rimraf) | `3.0.2` → `3.0.2` | [github](https://github.com/isaacs/rimraf) | - |
| [safe-buffer](https://npm.im/safe-buffer) | `5.1.2` → `5.1.2` | [github](https://github.com/feross/safe-buffer) | - |
| [safer-buffer](https://npm.im/safer-buffer) | `2.1.2` → `2.1.2` | [github](https://github.com/ChALkeR/safer-buffer) | - |
| [semver](https://npm.im/semver) | `7.3.4` → `7.3.4` | [github](https://github.com/npm/node-semver) | - |
| [set-blocking](https://npm.im/set-blocking) | `2.0.0` → `2.0.0` | [github](https://github.com/yargs/set-blocking) | - |
| [signal-exit](https://npm.im/signal-exit) | `3.0.3` → `3.0.3` | [github](https://github.com/tapjs/signal-exit) | - |
| [smart-buffer](https://npm.im/smart-buffer) | `4.1.0` → `4.1.0` | [github](https://github.com/JoshGlazebrook/smart-buffer) | - |
| [socks](https://npm.im/socks) | `2.5.1` → `2.5.1` | [github](https://github.com/JoshGlazebrook/socks) | - |
| [socks-proxy-agent](https://npm.im/socks-proxy-agent) | `5.0.0` → `5.0.0` | [github](https://github.com/TooTallNate/node-socks-proxy-agent) | - |
| [sorted-object](https://npm.im/sorted-object) | `2.0.1` → `2.0.1` | [github](https://github.com/domenic/sorted-object) | - |
| [spdx-correct](https://npm.im/spdx-correct) | `3.1.1` → `3.1.1` | [github](https://github.com/jslicense/spdx-correct.js) | - |
| [spdx-exceptions](https://npm.im/spdx-exceptions) | `2.3.0` → `2.3.0` | [github](https://github.com/kemitchell/spdx-exceptions.json) | - |
| [spdx-expression-parse](https://npm.im/spdx-expression-parse) | `3.0.1` → `3.0.1` | [github](https://github.com/jslicense/spdx-expression-parse.js) | - |
| [spdx-license-ids](https://npm.im/spdx-license-ids) | `3.0.7` → `3.0.7` | [github](https://github.com/jslicense/spdx-license-ids) | - |
| [sshpk](https://npm.im/sshpk) | `1.16.1` → `1.16.1` | [github](https://github.com/joyent/node-sshpk) | - |
| [ssri](https://npm.im/ssri) | `8.0.0` → `8.0.0` | [github](https://github.com/npm/ssri) | - |
| [string_decoder](https://npm.im/string_decoder) | `1.1.1` → `1.1.1` | [github](https://github.com/nodejs/string_decoder) | - |
| [string-width](https://npm.im/string-width) | `1.0.2` → `1.0.2` | [github](https://github.com/sindresorhus/string-width) | - |
| [string-width](https://npm.im/string-width) | `2.1.1` → `2.1.1` | [github](https://github.com/sindresorhus/string-width) | - |
| [string-width](https://npm.im/string-width) | `4.2.0` → `4.2.0` | [github](https://github.com/sindresorhus/string-width) | - |
| [stringify-package](https://npm.im/stringify-package) | `1.0.1` → `1.0.1` | [github](https://github.com/npm/stringify-package) | - |
| [strip-ansi](https://npm.im/strip-ansi) | `3.0.1` → `3.0.1` | [github](https://github.com/chalk/strip-ansi) | - |
| [strip-ansi](https://npm.im/strip-ansi) | `4.0.0` → `4.0.0` | [github](https://github.com/chalk/strip-ansi) | - |
| [strip-ansi](https://npm.im/strip-ansi) | `6.0.0` → `6.0.0` | [github](https://github.com/chalk/strip-ansi) | - |
| [supports-color](https://npm.im/supports-color) | `7.2.0` → `7.2.0` | [github](https://github.com/chalk/supports-color) | - |
| [tar](https://npm.im/tar) | `6.0.5` → `6.0.5` | [github](https://github.com/npm/node-tar) | - |
| [text-table](https://npm.im/text-table) | `0.2.0` → `0.2.0` | [github](https://github.com/substack/text-table) | - |
| [tiny-relative-date](https://npm.im/tiny-relative-date) | `1.3.0` → `1.3.0` | [github](https://github.com/wildlyinaccurate/relative-date) | - |
| [tough-cookie](https://npm.im/tough-cookie) | `2.5.0` → `2.5.0` | [github](https://github.com/salesforce/tough-cookie) | - |
| [treeverse](https://npm.im/treeverse) | `1.0.4` → `1.0.4` | [github](https://github.com/npm/treeverse) | - |
| [tunnel-agent](https://npm.im/tunnel-agent) | `0.6.0` → `0.6.0` | [github](https://github.com/mikeal/tunnel-agent) | - |
| [tweetnacl](https://npm.im/tweetnacl) | `0.14.5` → `0.14.5` | [github](https://github.com/dchest/tweetnacl-js) | - |
| [typedarray-to-buffer](https://npm.im/typedarray-to-buffer) | `3.1.5` → `3.1.5` | [github](https://github.com/feross/typedarray-to-buffer) | - |
| [unique-filename](https://npm.im/unique-filename) | `1.1.1` → `1.1.1` | [github](https://github.com/iarna/unique-filename) | - |
| [unique-slug](https://npm.im/unique-slug) | `2.0.2` → `2.0.2` | [github](https://github.com/iarna/unique-slug) | - |
| [uri-js](https://npm.im/uri-js) | `4.4.0` → `4.4.0` | [github](https://github.com/garycourt/uri-js) | - |
| [util-deprecate](https://npm.im/util-deprecate) | `1.0.2` → `1.0.2` | [github](https://github.com/TooTallNate/util-deprecate) | - |
| [uuid](https://npm.im/uuid) | `3.4.0` → `3.4.0` | [github](https://github.com/uuidjs/uuid) | - |
| [uuid](https://npm.im/uuid) | `8.3.2` → `8.3.2` | [github](https://github.com/uuidjs/uuid) | - |
| [validate-npm-package-license](https://npm.im/validate-npm-package-license) | `3.0.4` → `3.0.4` | [github](https://github.com/kemitchell/validate-npm-package-license.js) | - |
| [validate-npm-package-name](https://npm.im/validate-npm-package-name) | `3.0.0` → `3.0.0` | [github](https://github.com/npm/validate-npm-package-name) | - |
| [verror](https://npm.im/verror) | `1.10.0` → `1.10.0` | [github](https://github.com/davepacheco/node-verror) | - |
| [walk-up-path](https://npm.im/walk-up-path) | `1.0.0` → `1.0.0` | [github](https://github.com/isaacs/walk-up-path) | - |
| [wcwidth](https://npm.im/wcwidth) | `1.0.1` → `1.0.1` | [github](https://github.com/timoxley/wcwidth) | - |
| [which](https://npm.im/which) | `2.0.2` → `2.0.2` | [github](https://github.com/isaacs/node-which) | - |
| [wide-align](https://npm.im/wide-align) | `1.1.3` → `1.1.3` | [github](https://github.com/iarna/wide-align) | - |
| [wrappy](https://npm.im/wrappy) | `1.0.2` → `1.0.2` | [github](https://github.com/npm/wrappy) | - |
| [write-file-atomic](https://npm.im/write-file-atomic) | `3.0.3` → `3.0.3` | [github](https://github.com/npm/write-file-atomic) | - |
| [yallist](https://npm.im/yallist) | `4.0.0` → `4.0.0` | [github](https://github.com/isaacs/yallist) | - |

### Added (1)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [disk-space](https://npm.im/disk-space) | `1.1.0` | [github](https://github.com/idjem/disk-space) | - |

### Removed (5)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [axios](https://npm.im/axios) | `0.19.2` | [github](https://github.com/axios/axios) | - |
| [debug](https://npm.im/debug) | `3.1.0` | [github](https://github.com/visionmedia/debug) | - |
| [diskusage](https://npm.im/diskusage) | `1.1.3` | [github](https://github.com/jduncanator/node-diskusage) | - |
| [follow-redirects](https://npm.im/follow-redirects) | `1.5.10` | [github](https://github.com/follow-redirects/follow-redirects) | - |
| [ms](https://npm.im/ms) | `2.0.0` | [github](https://github.com/vercel/ms) | - |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.11**.