### PR TITLE
Stop trying to add o-fonts-assets to the npm cache

### DIFF
--- a/lib/primeNpmCache.js
+++ b/lib/primeNpmCache.js
@@ -19,7 +19,7 @@ const components = [
 	'@financial-times/o-editorial-typography',
 	'@financial-times/o-errors',
 	'@financial-times/o-expander',
-	'@financial-times/o-fonts-assets',
+// 	'@financial-times/o-fonts-assets',
 	'@financial-times/o-fonts',
 	'@financial-times/o-footer-services',
 	'@financial-times/o-footer',


### PR DESCRIPTION
o-fonts-assets is not on public npm registry, this used to work because we were using the origami npm registry and not the public registry

We want to use the public registry from now on, so we need to stop trying to add o-fonts-assets to the npm cache.