### PR TITLE
Make errors in v3 api be served as plain text and with nosniff enabled

### DIFF
--- a/lib/middleware/v3/createCssBundle.js
+++ b/lib/middleware/v3/createCssBundle.js
@@ -70,6 +70,7 @@ const createCssBundle = async (request, response) => {
 		response.endTime('bundleSass');
 
 		response.setHeader('Content-Type', 'text/css; charset=UTF-8');
+		response.setHeader('X-Content-Type-Options', 'nosniff');
 		response.setHeader('Cache-Control', 'public, max-age=86400, stale-if-error=604800, stale-while-revalidate=300000');
 		response.status(200);
 		response.send(bundle);
@@ -77,13 +78,12 @@ const createCssBundle = async (request, response) => {
 		Raven.captureException(err);
 		console.error(err, JSON.stringify(err));
 
-		response.setHeader('Content-Type', 'text/css; charset=UTF-8');
+		response.setHeader('Content-Type', 'text/plain; charset=UTF-8');
+		response.setHeader('X-Content-Type-Options', 'nosniff');
 		response.setHeader('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store');
 		response.status(400);
 
-		response.send(`/*${JSON.stringify(
-			'Origami Build Service returned an error: ' + err.message
-		)}*/`);
+		response.send('Origami Build Service returned an error: ' + JSON.stringify(err.message));
 	} finally {
 		await rmrf(bundleLocation, rimrafOptions);
 	}

--- a/lib/middleware/v3/createJavaScriptBundle.js
+++ b/lib/middleware/v3/createJavaScriptBundle.js
@@ -69,6 +69,7 @@ const createJavaScriptBundle = async (request, response) => {
 		response.endTime('bundleJavascript');
 
 		response.setHeader('Content-Type', 'application/javascript;charset=UTF-8');
+		response.setHeader('X-Content-Type-Options', 'nosniff');
 		response.setHeader('Cache-Control', 'public, max-age=86400, stale-if-error=604800, stale-while-revalidate=300000');
 		response.status(200);
 		response.send(bundle);
@@ -76,13 +77,12 @@ const createJavaScriptBundle = async (request, response) => {
 		Raven.captureException(err);
 		console.error(err, JSON.stringify(err));
 
-		response.setHeader('Content-Type', 'application/javascript;charset=UTF-8');
+		response.setHeader('Content-Type', 'text/plain;charset=UTF-8');
+		response.setHeader('X-Content-Type-Options', 'nosniff');
 		response.setHeader('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store');
 		response.status(400);
 
-		response.send(`throw new Error(${JSON.stringify(
-			'Origami Build Service returned an error: ' + err.message
-		)})`);
+		response.send('Origami Build Service returned an error: ' + JSON.stringify(err.message));
 	} finally {
 		await rmrf(bundleLocation, rimrafOptions);
 	}

--- a/lib/middleware/v3/parseBrandParameter.js
+++ b/lib/middleware/v3/parseBrandParameter.js
@@ -14,11 +14,11 @@ const UserError = require('../../utils/usererror');
  */
 const parseBrandParameter = brand => {
 	if (typeof brand !== 'string') {
-		throw new UserError('The brand query parameter must be a string. Either "master", "internal", or "whitelabel".');
+		throw new UserError('The brand query parameter must be a string. Either `master`, `internal`, or `whitelabel`.');
 	}
 
 	if (brand.length === 0) {
-		throw new UserError('The brand query parameter can not be empty. It must be set to either "master", "internal", or "whitelabel".');
+		throw new UserError('The brand query parameter can not be empty. It must be set to either `master`, `internal`, or `whitelabel`.');
 	}
 
 	switch (brand) {
@@ -28,7 +28,7 @@ const parseBrandParameter = brand => {
 			return brand;
 		}
 		default: {
-			throw new UserError('The brand query parameter must be either "master", "internal", or "whitelabel".');
+			throw new UserError('The brand query parameter must be either `master`, `internal`, or `whitelabel`.');
 		}
 	}
 };

--- a/lib/middleware/v3/parseModulesParameter.js
+++ b/lib/middleware/v3/parseModulesParameter.js
@@ -45,7 +45,7 @@ const parseModulesParameter = modules => {
 	const moduleNames = parsedModules.map(mod => {
 		if (/^\s/.test(mod) || /\s$/.test(mod)) {
 			throw new UserError(
-				`The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from "${mod}" to make the module name valid.`
+				`The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \`${mod}\` to make the module name valid.`
 			);
 		}
 		if (mod.startsWith('@')) {

--- a/test/integration/v3-bundles-css.test.js
+++ b/test/integration/v3-bundles-css.test.js
@@ -32,7 +32,11 @@ describe('GET /v3/bundles/css', function() {
 
         it('should respond with the expected `Content-Type` header', function(done) {
 			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
     });
 
     describe('when a valid module, valid system-code and invalid brand is requested', function() {
@@ -55,13 +59,17 @@ describe('GET /v3/bundles/css', function() {
         it('should respond with the css', function(done) {
             this.request
                 .expect(({text}) => {
-                    proclaim.deepStrictEqual(text, '/*"Origami Build Service returned an error: The brand query parameter must be either \\"master\\", \\"internal\\", or \\"whitelabel\\"."*/');
+                    proclaim.deepStrictEqual(text, 'Origami Build Service returned an error: "The brand query parameter must be either `master`, `internal`, or `whitelabel`."');
                 }).end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
     });
 
     describe('when an invalid module, valid brand and valid system-code is requested', function() {
@@ -83,13 +91,17 @@ describe('GET /v3/bundles/css', function() {
 
         it('should respond with the css', function(done) {
             this.request.expect(({text}) => {
-                proclaim.deepStrictEqual(text,'/*"Origami Build Service returned an error: hello-nonexistent-module@1 is not in the npm regsitry"*/');
+                proclaim.deepStrictEqual(text,'Origami Build Service returned an error: "hello-nonexistent-module@1 is not in the npm regsitry"');
             }).end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
     });
 
     describe('when an invalid module is requested (nonexistent)', function() {
@@ -110,8 +122,12 @@ describe('GET /v3/bundles/css', function() {
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -136,6 +152,10 @@ describe('GET /v3/bundles/css', function() {
         //     this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
         // });
 
+        // it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+		// 	this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        // });
+
     // });
 
     describe('when the modules parameter is missing', function() {
@@ -155,12 +175,16 @@ describe('GET /v3/bundles/css', function() {
         });
 
         it('should respond with an error message', function(done) {
-            this.request.expect('/*"Origami Build Service returned an error: The modules query parameter can not be empty."*/').end(done);
+            this.request.expect('Origami Build Service returned an error: "The modules query parameter can not be empty."').end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -181,12 +205,16 @@ describe('GET /v3/bundles/css', function() {
         });
 
         it('should respond with an error message', function(done) {
-            this.request.expect('/*"Origami Build Service returned an error: The modules query parameter must be a string."*/').end(done);
+            this.request.expect('Origami Build Service returned an error: "The modules query parameter must be a string."').end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -208,12 +236,16 @@ describe('GET /v3/bundles/css', function() {
         });
 
         it('should respond with an error message', function(done) {
-            this.request.expect('/*"Origami Build Service returned an error: The modules query parameter contains module names which are not valid: http://1.2.3.4/."*/').end(done);
+            this.request.expect('Origami Build Service returned an error: "The modules query parameter contains module names which are not valid: http://1.2.3.4/."').end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'text/css; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 

--- a/test/integration/v3-bundles-js.test.js
+++ b/test/integration/v3-bundles-js.test.js
@@ -71,7 +71,11 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with the expected `Content-Type` header', function(done) {
 			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -90,8 +94,12 @@ describe('GET /v3/bundles/js', function() {
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -114,7 +122,11 @@ describe('GET /v3/bundles/js', function() {
     //     });
 
     // it('should respond with the expected `Content-Type` header', function(done) {
-    //     this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
+    //     this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+    // });
+
+    // it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+    //     this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
     // });
 
     // });
@@ -133,12 +145,16 @@ describe('GET /v3/bundles/js', function() {
         });
 
         it('should respond with an error message', function(done) {
-            this.request.expect('throw new Error("Origami Build Service returned an error: The modules query parameter can not be empty.")').end(done);
+            this.request.expect('Origami Build Service returned an error: "The modules query parameter can not be empty."').end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -156,12 +172,16 @@ describe('GET /v3/bundles/js', function() {
         });
 
         it('should respond with an error message', function(done) {
-            this.request.expect('throw new Error("Origami Build Service returned an error: The modules query parameter must be a string.")').end(done);
+            this.request.expect('Origami Build Service returned an error: "The modules query parameter must be a string."').end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -181,18 +201,22 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with an error message', function(done) {
             this.request.expect(({text}) => {
-                proclaim.deepStrictEqual(text, 'throw new Error("Origami Build Service returned an error: The modules query parameter contains module names which are not valid: http://1.2.3.4/.")');
+                proclaim.deepStrictEqual(text, 'Origami Build Service returned an error: "The modules query parameter contains module names which are not valid: http://1.2.3.4/."');
             }).end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
     });
 
     describe('when the callback parameter is an invalid value', function() {
         const moduleName = '@financial-times/o-utils@1.1.7';
-        const callback = 'console.log("you got hacked!");//';
+        const callback = 'console.log("you got hacked!";//';
         const systemCode = 'origami';
 
         beforeEach(function() {
@@ -207,13 +231,17 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with an error message', function(done) {
             this.request.expect(({text}) => {
-                proclaim.deepStrictEqual(text, 'throw new Error("Origami Build Service returned an error: The callback query parameter must be a valid name for a JavaScript variable or function.")');
+                proclaim.deepStrictEqual(text, 'Origami Build Service returned an error: "The callback query parameter must be a valid name for a JavaScript variable or function."');
             }).end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -234,7 +262,7 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with the bundled JavaScript and call the callback with the requrested components', function(done) {
             this.request.expect(({text}) => {
-                // proclaim.deepStrictEqual(text, '(function(){"use strict";function T(e,n){var t;if(typeof Symbol=="undefined"||e[Symbol.iterator]==null){if(Array.isArray(e)||(t=A(e))||n&&e&&typeof e.length=="number"){t&&(e=t);var c=0,b=function(){};return{s:b,n:function(){return c>=e.length?{done:!0}:{done:!1,value:e[c++]}},e:function(a){throw a},f:b}}throw new TypeError("Invalid attempt to iterate non-iterable instance.\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}var d=!0,v=!1,g;return{s:function(){t=e[Symbol.iterator]()},n:function(){var a=t.next();return d=a.done,a},e:function(a){v=!0,g=a},f:function(){try{!d&&t.return!=null&&t.return()}finally{if(v)throw g}}}}function A(e,n){if(!e)return;if(typeof e=="string")return j(e,n);var t=Object.prototype.toString.call(e).slice(8,-1);if(t==="Object"&&e.constructor&&(t=e.constructor.name),t==="Map"||t==="Set")return Array.from(e);if(t==="Arguments"||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t))return j(e,n)}function j(e,n){(n==null||n>e.length)&&(n=e.length);for(var t=0,c=new Array(n);t<n;t++)c[t]=e[t];return c}function O(e){return typeof Symbol=="function"&&typeof Symbol.iterator=="symbol"?O=function(t){return typeof t}:O=function(t){return t&&typeof Symbol=="function"&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t},O(e)}(function(){var e=Object.create,n=Object.defineProperty,t=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,b=Object.getOwnPropertyNames,d=Object.getOwnPropertyDescriptor,v=function(r){return n(r,"__esModule",{value:!0})},g=function(r,o){return function(){return o||(o={exports:{}},r(o.exports,o)),o.exports}},f=function(r,o,s){if(v(r),o&&O(o)=="object"||typeof o=="function"){var l=T(b(o)),u;try{var m=function(){var i=u.value;!c.call(r,i)&&i!=="default"&&n(r,i,{get:function(){return o[i]},enumerable:!(s=d(o,i))||s.enumerable})};for(l.s();!(u=l.n()).done;)m()}catch(p){l.e(p)}finally{l.f()}}return r},a=function(r){return r&&r.__esModule?r:f(n(r!=null?e(t(r)):{},"default",{value:r,enumerable:!0}),r)},w=g(function(y){"use strict";Object.defineProperty(y,"__esModule",{value:!0}),y.debounce=r,y.throttle=o;function r(s,l){var u;return function(){var m=this,p=arguments,i=function(){u=null,s.apply(m,p)};clearTimeout(u),u=setTimeout(i,l)}}function o(s,l){var u;return function(){var m=this;if(u)return;var p=arguments,i=function(){u=null,s.apply(m,p)};u=setTimeout(i,l)}}}),h=a(w()),_={};typeof Origami=="undefined"&&(self.Origami={}),self.Origami["@financial-times/o-utils"]=h,_["@financial-times/o-utils"]=h,typeof start_app=="function"&&start_app(_)})();})();\n');
+                // proclaim.deepStrictEqual(text, '(function(){"use strict";function T(e,n){var t;if(typeof Symbol=="undefined"||e[Symbol.iterator]==null){if(Array.isArray(e)||(t=A(e))||n&&e&&typeof e.length=="number"{t&&(e=t);var c=0,b=function(){};return{s:b,n:function(){return c>=e.length?{done:!0}:{done:!1,value:e[c++]}},e:function(a){throw a},f:b}}throw new TypeError("Invalid attempt to iterate non-iterable instance.\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."}var d=!0,v=!1,g;return{s:function(){t=e[Symbol.iterator]()},n:function(){var a=t.next();return d=a.done,a},e:function(a){v=!0,g=a},f:function(){try{!d&&t.return!=null&&t.return()}finally{if(v)throw g}}}}function A(e,n){if(!e)return;if(typeof e=="string"return j(e,n);var t=Object.prototype.toString.call(e).slice(8,-1);if(t==="Object"&&e.constructor&&(t=e.constructor.name),t==="Map"||t==="Set"return Array.from(e);if(t==="Arguments"||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t))return j(e,n)}function j(e,n){(n==null||n>e.length)&&(n=e.length);for(var t=0,c=new Array(n);t<n;t++)c[t]=e[t];return c}function O(e){return typeof Symbol=="function"&&typeof Symbol.iterator=="symbol"?O=function(t){return typeof t}:O=function(t){return t&&typeof Symbol=="function"&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t},O(e)}(function(){var e=Object.create,n=Object.defineProperty,t=Object.getPrototypeOf,c=Object.prototype.hasOwnProperty,b=Object.getOwnPropertyNames,d=Object.getOwnPropertyDescriptor,v=function(r){return n(r,"__esModule",{value:!0})},g=function(r,o){return function(){return o||(o={exports:{}},r(o.exports,o)),o.exports}},f=function(r,o,s){if(v(r),o&&O(o)=="object"||typeof o=="function"{var l=T(b(o)),u;try{var m=function(){var i=u.value;!c.call(r,i)&&i!=="default"&&n(r,i,{get:function(){return o[i]},enumerable:!(s=d(o,i))||s.enumerable})};for(l.s();!(u=l.n()).done;)m()}catch(p){l.e(p)}finally{l.f()}}return r},a=function(r){return r&&r.__esModule?r:f(n(r!=null?e(t(r)):{},"default",{value:r,enumerable:!0}),r)},w=g(function(y){"use strict";Object.defineProperty(y,"__esModule",{value:!0}),y.debounce=r,y.throttle=o;function r(s,l){var u;return function(){var m=this,p=arguments,i=function(){u=null,s.apply(m,p)};clearTimeout(u),u=setTimeout(i,l)}}function o(s,l){var u;return function(){var m=this;if(u)return;var p=arguments,i=function(){u=null,s.apply(m,p)};u=setTimeout(i,l)}}}),h=a(w()),_={};typeof Origami=="undefined"&&(self.Origami={}),self.Origami["@financial-times/o-utils"]=h,_["@financial-times/o-utils"]=h,typeof start_app=="function"&&start_app(_)})();})();\n');
                 proclaim.deepStrictEqual(getEcmaVersion(text), 5);
 
                 const script = new vm.Script(text);
@@ -257,7 +285,11 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with the expected `Content-Type` header', function(done) {
 			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 
@@ -277,13 +309,17 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with an error message', function(done) {
             this.request.expect(({text}) => {
-                proclaim.deepStrictEqual(text, 'throw new Error("Origami Build Service returned an error: The system_code query parameter must be a valid Biz-Ops System Code.")');
+                proclaim.deepStrictEqual(text, 'Origami Build Service returned an error: "The system_code query parameter must be a valid Biz-Ops System Code."');
             }).end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
     describe('when the system_code parameter is missing', function() {
@@ -301,13 +337,17 @@ describe('GET /v3/bundles/js', function() {
 
         it('should respond with an error message', function(done) {
             this.request.expect(({text}) => {
-                proclaim.deepStrictEqual(text, 'throw new Error("Origami Build Service returned an error: The system_code query parameter must be a string.")');
+                proclaim.deepStrictEqual(text, 'Origami Build Service returned an error: "The system_code query parameter must be a string."');
             }).end(done);
         });
 
         it('should respond with the expected `Content-Type` header', function(done) {
-			this.request.expect('Content-Type', 'application/javascript; charset=utf-8').end(done);
-		});
+			this.request.expect('Content-Type', 'text/plain; charset=utf-8').end(done);
+        });
+
+        it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function(done) {
+			this.request.expect('X-Content-Type-Options', 'nosniff').end(done);
+        });
 
     });
 

--- a/test/unit/lib/middleware/v3/createCssBundle.test.js
+++ b/test/unit/lib/middleware/v3/createCssBundle.test.js
@@ -71,7 +71,7 @@ describe('createCssBundle', function () {
 
 			proclaim.deepStrictEqual(
 				response.getHeader('content-type'),
-				'text/css; charset=UTF-8'
+				'text/plain; charset=UTF-8'
 			);
 			proclaim.deepStrictEqual(
 				response.getHeader('cache-control'),
@@ -81,7 +81,7 @@ describe('createCssBundle', function () {
 
 			proclaim.deepStrictEqual(
 				bundle,
-				'/*"Origami Build Service returned an error: The modules query parameter can not be empty."*/'
+				'Origami Build Service returned an error: \"The modules query parameter can not be empty.\"'
 			);
 		});
 	});
@@ -109,7 +109,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -119,7 +119,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The modules query parameter can not be empty."*/'
+					'Origami Build Service returned an error: \"The modules query parameter can not be empty.\"'
 				);
 			});
 		}
@@ -148,7 +148,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -158,7 +158,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The modules query parameter contains duplicate module names."*/'
+					'Origami Build Service returned an error: \"The modules query parameter contains duplicate module names.\"'
 				);
 			});
 		}
@@ -186,7 +186,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -196,7 +196,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The modules query parameter can not contain empty module names."*/'
+					'Origami Build Service returned an error: \"The modules query parameter can not contain empty module names.\"'
 				);
 			});
 		}
@@ -224,7 +224,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -234,7 +234,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \\" o-test@1\\" to make the module name valid."*/'
+					'Origami Build Service returned an error: \"The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from ` o-test@1` to make the module name valid.\"'
 				);
 			});
 		}
@@ -262,7 +262,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -272,7 +272,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \\"o-test@1 \\" to make the module name valid."*/'
+					'Origami Build Service returned an error: \"The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from `o-test@1 ` to make the module name valid.\"'
 				);
 			});
 		}
@@ -300,7 +300,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -310,7 +310,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The bundle request contains o-test with no version range, a version range is required.\\nPlease refer to TODO (build service documentation) for what is a valid version."*/'
+					'Origami Build Service returned an error: \"The bundle request contains o-test with no version range, a version range is required.\\nPlease refer to TODO (build service documentation) for what is a valid version.\"'
 				);
 			});
 		}
@@ -338,7 +338,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -348,7 +348,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The version 5wg in o-test@5wg is not a valid version.\\nPlease refer to TODO (build service documentation) for what is a valid version."*/'
+					'Origami Build Service returned an error: \"The version 5wg in o-test@5wg is not a valid version.\\nPlease refer to TODO (build service documentation) for what is a valid version.\"'
 				);
 			});
 		}
@@ -376,7 +376,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -386,7 +386,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The modules query parameter contains module names which are not valid: o-TeSt."*/'
+					'Origami Build Service returned an error: \"The modules query parameter contains module names which are not valid: o-TeSt.\"'
 				);
 			});
 		}
@@ -415,7 +415,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -425,7 +425,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The brand query parameter must be either \\"master\\", \\"internal\\", or \\"whitelabel\\"."*/'
+					'Origami Build Service returned an error: \"The brand query parameter must be either `master`, `internal`, or `whitelabel`.\"'
 				);
 			});
 		}
@@ -453,7 +453,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -463,7 +463,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The brand query parameter must be a string. Either \\"master\\", \\"internal\\", or \\"whitelabel\\"."*/'
+					'Origami Build Service returned an error: \"The brand query parameter must be a string. Either `master`, `internal`, or `whitelabel`.\"'
 				);
 			});
 		}
@@ -492,7 +492,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -502,7 +502,7 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'/*"Origami Build Service returned an error: The system_code query parameter must be a string."*/'
+					'Origami Build Service returned an error: \"The system_code query parameter must be a string.\"'
 				);
 			});
 		}
@@ -532,11 +532,11 @@ describe('createCssBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'text/css; charset=UTF-8'
+					'text/plain; charset=UTF-8'
 					);
 						proclaim.deepStrictEqual(
 							bundle,
-							'/*"Origami Build Service returned an error: The system_code query parameter must be a valid Biz-Ops System Code."*/'
+							'Origami Build Service returned an error: \"The system_code query parameter must be a valid Biz-Ops System Code.\"'
 						);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),

--- a/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
+++ b/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
@@ -89,7 +89,7 @@ describe('createJavaScriptBundle', function () {
 
 			proclaim.deepStrictEqual(
 				response.getHeader('content-type'),
-				'application/javascript;charset=UTF-8'
+				'text/plain;charset=UTF-8'
 			);
 			proclaim.deepStrictEqual(
 				response.getHeader('cache-control'),
@@ -99,17 +99,8 @@ describe('createJavaScriptBundle', function () {
 
 			proclaim.deepStrictEqual(
 				bundle,
-				'throw new Error("Origami Build Service returned an error: The modules query parameter can not be empty.")'
+				'Origami Build Service returned an error: "The modules query parameter can not be empty."'
 			);
-			proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-			const script = new vm.Script(bundle);
-
-			const context = {};
-			context.self = context;
-			proclaim.throws(function () {
-				script.runInNewContext(context);
-			}, 'Origami Build Service returned an error: The modules query parameter can not be empty.');
 		});
 	});
 
@@ -137,7 +128,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -147,17 +138,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The modules query parameter can not be empty.")'
+					'Origami Build Service returned an error: "The modules query parameter can not be empty."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The modules query parameter can not be empty.');
 			});
 		}
 	);
@@ -186,7 +168,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -196,17 +178,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The modules query parameter contains duplicate module names.")'
+					'Origami Build Service returned an error: "The modules query parameter contains duplicate module names."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The modules query parameter contains duplicate module names.');
 			});
 		}
 	);
@@ -234,7 +207,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -244,17 +217,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The modules query parameter can not contain empty module names.")'
+					'Origami Build Service returned an error: "The modules query parameter can not contain empty module names."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The modules query parameter can not contain empty module names.');
 			});
 		}
 	);
@@ -282,7 +246,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -292,17 +256,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \\" o-test@1\\" to make the module name valid.")'
+					'Origami Build Service returned an error: "The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from ` o-test@1` to make the module name valid."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \" o-test@1\" to make the module name valid.');
 			});
 		}
 	);
@@ -330,7 +285,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -340,17 +295,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \\"o-test@1 \\" to make the module name valid.")'
+					'Origami Build Service returned an error: "The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from `o-test@1 ` to make the module name valid."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from \"o-test@1 \" to make the module name valid.');
 			});
 		}
 	);
@@ -378,7 +324,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -388,17 +334,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The bundle request contains o-test with no version range, a version range is required.\\nPlease refer to TODO (build service documentation) for what is a valid version.")'
+					'Origami Build Service returned an error: "The bundle request contains o-test with no version range, a version range is required.\\nPlease refer to TODO (build service documentation) for what is a valid version."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The bundle request contains o-test with no version range, a version range is required.\nPlease refer to TODO (build service documentation) for what is a valid version.');
 			});
 		}
 	);
@@ -426,7 +363,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -436,17 +373,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The version 5wg in o-test@5wg is not a valid version.\\nPlease refer to TODO (build service documentation) for what is a valid version.")'
+					'Origami Build Service returned an error: "The version 5wg in o-test@5wg is not a valid version.\\nPlease refer to TODO (build service documentation) for what is a valid version."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The version 5wg in o-test@5wg is not a valid version.\nPlease refer to TODO (build service documentation) for what is a valid version.');
 			});
 		}
 	);
@@ -474,7 +402,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -484,17 +412,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The modules query parameter contains module names which are not valid: o-TeSt.")'
+					'Origami Build Service returned an error: "The modules query parameter contains module names which are not valid: o-TeSt."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The modules query parameter contains module names which are not valid: o-TeSt.');
 			});
 		}
 	);
@@ -523,7 +442,7 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					response.getHeader('content-type'),
-					'application/javascript;charset=UTF-8'
+					'text/plain;charset=UTF-8'
 				);
 				proclaim.deepStrictEqual(
 					response.getHeader('cache-control'),
@@ -533,17 +452,8 @@ describe('createJavaScriptBundle', function () {
 
 				proclaim.deepStrictEqual(
 					bundle,
-					'throw new Error("Origami Build Service returned an error: The system_code query parameter must be a valid Biz-Ops System Code.")'
+					'Origami Build Service returned an error: "The system_code query parameter must be a valid Biz-Ops System Code."'
 				);
-				proclaim.deepStrictEqual(getEcmaVersion(bundle), 5);
-
-				const script = new vm.Script(bundle);
-
-				const context = {};
-				context.self = context;
-				proclaim.throws(function () {
-					script.runInNewContext(context);
-				}, 'Origami Build Service returned an error: The system_code query parameter must be a valid Biz-Ops System Code.');
 			});
 		}
 	);

--- a/test/unit/lib/middleware/v3/parseBrandParameters.test.js
+++ b/test/unit/lib/middleware/v3/parseBrandParameters.test.js
@@ -19,7 +19,7 @@ describe('parseBrandParameter', () => {
 
 		proclaim.throws(() => {
 			parseBrandParameter();
-		}, 'The brand query parameter must be a string. Either "master", "internal", or "whitelabel".');
+		}, 'The brand query parameter must be a string. Either `master`, `internal`, or `whitelabel`.');
 	});
 
 	it('throws UserError if brand parameter is not a string', async () => {
@@ -29,7 +29,7 @@ describe('parseBrandParameter', () => {
 
 		proclaim.throws(() => {
 			parseBrandParameter(1);
-		}, 'The brand query parameter must be a string. Either "master", "internal", or "whitelabel".');
+		}, 'The brand query parameter must be a string. Either `master`, `internal`, or `whitelabel`.');
 
 		proclaim.throws(() => {
 			parseBrandParameter(true);
@@ -37,7 +37,7 @@ describe('parseBrandParameter', () => {
 
 		proclaim.throws(() => {
 			parseBrandParameter(true);
-		}, 'The brand query parameter must be a string. Either "master", "internal", or "whitelabel".');
+		}, 'The brand query parameter must be a string. Either `master`, `internal`, or `whitelabel`.');
 
 		proclaim.throws(() => {
 			parseBrandParameter([]);
@@ -45,7 +45,7 @@ describe('parseBrandParameter', () => {
 
 		proclaim.throws(() => {
 			parseBrandParameter([]);
-		}, 'The brand query parameter must be a string. Either "master", "internal", or "whitelabel".');
+		}, 'The brand query parameter must be a string. Either `master`, `internal`, or `whitelabel`.');
 	});
 
 	it('throws UserError if brand parameter is empty string', async () => {
@@ -55,7 +55,7 @@ describe('parseBrandParameter', () => {
 
 		proclaim.throws(() => {
 			parseBrandParameter('');
-		}, 'The brand query parameter can not be empty. It must be set to either "master", "internal", or "whitelabel".');
+		}, 'The brand query parameter can not be empty. It must be set to either `master`, `internal`, or `whitelabel`.');
 	});
 
 	it('throws UserError if brand parameter is not a valid value', async () => {
@@ -65,6 +65,6 @@ describe('parseBrandParameter', () => {
 
 		proclaim.throws(() => {
 			parseBrandParameter('origami');
-		}, 'The brand query parameter must be either "master", "internal", or "whitelabel".');
+		}, 'The brand query parameter must be either `master`, `internal`, or `whitelabel`.');
 	});
 });

--- a/test/unit/lib/middleware/v3/parseModulesParameters.test.js
+++ b/test/unit/lib/middleware/v3/parseModulesParameters.test.js
@@ -48,7 +48,7 @@ describe('parseModulesParameter', () => {
 
 		proclaim.throws(() => {
 			parseModulesParameter(' @ft/o-test@1');
-		}, 'The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from " @ft/o-test@1" to make the module name valid.');
+		}, 'The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from ` @ft/o-test@1` to make the module name valid.');
 	});
 
 	it('throws UserError if modules parameter contains module name with whitespace at the end', async () => {
@@ -58,11 +58,11 @@ describe('parseModulesParameter', () => {
 
 		proclaim.throws(() => {
 			parseModulesParameter('o-test@1 ');
-		}, 'The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from "o-test@1 " to make the module name valid.');
+		}, 'The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from `o-test@1 ` to make the module name valid.');
 
 		proclaim.throws(() => {
 			parseModulesParameter('@ft/o-test@1 ');
-		}, 'The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from "@ft/o-test@1 " to make the module name valid.');
+		}, 'The modules query parameter contains module names which have whitespace at either the start of end of their name. Remove the whitespace from `@ft/o-test@1 ` to make the module name valid.');
 	});
 
 	it('throws UserError if modules parameter contains module name without a version', async () => {


### PR DESCRIPTION
This ensures that we are not susceptible to any XSS attacks on the error responses for v3