### PR TITLE
Install `o-fonts-assets` with Github for the v3 files endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,12 @@ jobs:
     - run: make test-unit-coverage
       env:
         ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+        DEBUG_SAFE_TO_LOG: ${{ secrets.DEBUG_SAFE_TO_LOG }}
     - run: make test-integration
       env:
         ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+        DEBUG_SAFE_TO_LOG: ${{ secrets.DEBUG_SAFE_TO_LOG }}
     - run: make test-old
       env:
         ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+        DEBUG_SAFE_TO_LOG: ${{ secrets.DEBUG_SAFE_TO_LOG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,11 @@ jobs:
     - run: npm ci
     - run: make verify
     - run: make test-unit-coverage
+      env:
+        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
     - run: make test-integration
+      env:
+        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
     - run: make test-old
+      env:
+        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
     - uses: actions/setup-node@v2.1.4
       with:
         node-version: 12.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,9 @@ jobs:
     - run: make test-unit-coverage
       env:
         ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
-        DEBUG_SAFE_TO_LOG: ${{ secrets.DEBUG_SAFE_TO_LOG }}
     - run: make test-integration
       env:
         ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
-        DEBUG_SAFE_TO_LOG: ${{ secrets.DEBUG_SAFE_TO_LOG }}
     - run: make test-old
       env:
         ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
-        DEBUG_SAFE_TO_LOG: ${{ secrets.DEBUG_SAFE_TO_LOG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+          persist-credentials: false
+    - run: git config --global url."https://${{ secrets.ORIGAMI_GITHUB_TOKEN }}@github.com/".insteadOf ssh://git@github.com/
     - uses: actions/setup-node@v2.1.4
       with:
         node-version: 12.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     - run: make verify
     - run: make test-unit-coverage
       env:
-        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+        ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
     - run: make test-integration
       env:
-        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+        ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
     - run: make test-old
       env:
-        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
+        ORIGAMI_GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We configure Origami Build Service using environment variables. In development, 
 
 ### Required in Heroku
 
-  * `ORIGAMI_GITHUB_TOKEN`: A GitHub token with permission to read the private `o-fonts-assets` repository.
+  * `GITHUB_TOKEN`: A GitHub token with permission to read the private `o-fonts-assets` repository.
   * `GRAPHITE_API_KEY`: The FT's internal Graphite API key
   * `GRAPHITE_HOST`: The hostname of a Graphite server to gather metrics with.
   * `PREFERRED_HOSTNAME`: The hostname to use in documentation and as a base URL in bundle requests. This defaults to `www.ft.com/__origami/service/build`.
@@ -70,7 +70,7 @@ We configure Origami Build Service using environment variables. In development, 
 
 #### Deprecated:
 
-The following keys are required for v2 of the Build Service. They are deprecated and should not be used when developing new features, instead use `ORIGAMI_GITHUB_TOKEN`.
+The following keys are required for v2 of the Build Service. They are deprecated and should not be used when developing new features, instead use `GITHUB_TOKEN`.
 
   * `GITHUB_USERNAME`: A GitHub username with permission to view required private repositories.
   * `GITHUB_PASSWORD`: The GitHub password corresponding to `GITHUB_USERNAME`.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ We configure Origami Build Service using environment variables. In development, 
 
 ### Required in Heroku
 
-  * `GITHUB_PASSWORD`: The GitHub password corresponding to `GITHUB_USERNAME`.
-  * `GITHUB_USERNAME`: A GitHub username with permission to view required private repositories.
+  * `GITHUB_TOKEN`: A GitHub token with permission to read the private `o-fonts-assets` repository.
   * `GRAPHITE_API_KEY`: The FT's internal Graphite API key
   * `GRAPHITE_HOST`: The hostname of a Graphite server to gather metrics with.
   * `PREFERRED_HOSTNAME`: The hostname to use in documentation and as a base URL in bundle requests. This defaults to `www.ft.com/__origami/service/build`.
@@ -68,6 +67,13 @@ We configure Origami Build Service using environment variables. In development, 
   * `CHANGE_API_KEY`: The change-log API key to use when creating and closing change-logs.
   * `RELEASE_ENV`: The Salesforce environment to include in change-logs. One of `Test` or `Production`
   * `SENTRY_DSN`: The Sentry URL to send error information to
+
+#### Deprecated:
+
+The following keys are required for v2 of the Build Service. They are deprecated and should not be used when developing new features, instead use `GITHUB_TOKEN`.
+
+  * `GITHUB_USERNAME`: A GitHub username with permission to view required private repositories.
+  * `GITHUB_PASSWORD`: The GitHub password corresponding to `GITHUB_USERNAME`.
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We configure Origami Build Service using environment variables. In development, 
 
 ### Required in Heroku
 
-  * `GITHUB_TOKEN`: A GitHub token with permission to read the private `o-fonts-assets` repository.
+  * `ORIGAMI_GITHUB_TOKEN`: A GitHub token with permission to read the private `o-fonts-assets` repository.
   * `GRAPHITE_API_KEY`: The FT's internal Graphite API key
   * `GRAPHITE_HOST`: The hostname of a Graphite server to gather metrics with.
   * `PREFERRED_HOSTNAME`: The hostname to use in documentation and as a base URL in bundle requests. This defaults to `www.ft.com/__origami/service/build`.
@@ -70,7 +70,7 @@ We configure Origami Build Service using environment variables. In development, 
 
 #### Deprecated:
 
-The following keys are required for v2 of the Build Service. They are deprecated and should not be used when developing new features, instead use `GITHUB_TOKEN`.
+The following keys are required for v2 of the Build Service. They are deprecated and should not be used when developing new features, instead use `ORIGAMI_GITHUB_TOKEN`.
 
   * `GITHUB_USERNAME`: A GitHub username with permission to view required private repositories.
   * `GITHUB_PASSWORD`: The GitHub password corresponding to `GITHUB_USERNAME`.

--- a/lib/build-service.js
+++ b/lib/build-service.js
@@ -12,10 +12,6 @@ module.exports = buildService;
 
 function buildService(options) {
 
-	console.log({
-		safeEnvironmentVariable: process.env.DEBUG_SAFE_TO_LOG
-	});
-
 	const health = healthChecks(options);
 	options.healthCheck = health.checks();
 	options.goodToGoTest = health.gtg();

--- a/lib/build-service.js
+++ b/lib/build-service.js
@@ -12,6 +12,10 @@ module.exports = buildService;
 
 function buildService(options) {
 
+	console.log({
+		safeEnvironmentVariable: process.env.DEBUG_SAFE_TO_LOG
+	});
+
 	const health = healthChecks(options);
 	options.healthCheck = health.checks();
 	options.goodToGoTest = health.gtg();

--- a/lib/middleware/v3/outputFont.js
+++ b/lib/middleware/v3/outputFont.js
@@ -54,7 +54,7 @@ const outputFont = async (request, response) => {
 		const version = parseVersionParameter(request.query.version);
 		response.endTime('parseVersionParameter');
 		const moduleName = '@financial-times/o-fonts-assets';
-		const githubToken = process.env.ORIGAMI_GITHUB_TOKEN;
+		const githubToken = process.env.GITHUB_TOKEN;
 		const module = {
 			[moduleName]: `git+https://${githubToken}:x-oauth-basic@github.com/Financial-Times/o-fonts-assets.git#semver:${version}`
 		};

--- a/lib/middleware/v3/outputFont.js
+++ b/lib/middleware/v3/outputFont.js
@@ -54,7 +54,7 @@ const outputFont = async (request, response) => {
 		const version = parseVersionParameter(request.query.version);
 		response.endTime('parseVersionParameter');
 		const moduleName = '@financial-times/o-fonts-assets';
-		const githubToken = process.env.GITHUB_TOKEN;
+		const githubToken = process.env.ORIGAMI_GITHUB_TOKEN;
 		const module = {
 			[moduleName]: `git+https://${githubToken}:x-oauth-basic@github.com/Financial-Times/o-fonts-assets.git#semver:${version}`
 		};

--- a/lib/middleware/v3/outputFont.js
+++ b/lib/middleware/v3/outputFont.js
@@ -54,8 +54,9 @@ const outputFont = async (request, response) => {
 		const version = parseVersionParameter(request.query.version);
 		response.endTime('parseVersionParameter');
 		const moduleName = '@financial-times/o-fonts-assets';
+		const githubToken = process.env.GITHUB_TOKEN;
 		const module = {
-			[moduleName]: version
+			[moduleName]: `git+https://${githubToken}:x-oauth-basic@github.com/Financial-Times/o-fonts-assets.git#semver:${version}`
 		};
 
 		response.startTime('parseFontNameParameter');


### PR DESCRIPTION
We install from the Github repository because `o-fonts-assets` is
not available via npm as it must remain private for license reasons.

With our current Github license we could publish `o-fonts-assets`
to the Github packages registry privately. However we would have
to use a different scope to `@financial-times` so that we can install
from both the Github and npm registry. Unless we were to move all
`@financial-times` packages to the Github packages registry. We
think the later would be the best approach but would take time
to propose and implement across the ft. Hence for now we opted
to install the Github repository directly.

Update from Jake:
>There is also the third option of waiting to see if github/npm will 
>solve this for us via https://github.com/npm/rfcs/issues/275 or 
>https://github.com/npm/feedback/discussions/87