### PR TITLE
Return an error page if using the v2 api with an origami spec v2 component

### DIFF
--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -11,6 +11,7 @@ const hostnames = require('./utils/hostnames');
 const gulp = require('gulp');
 const obt = require('./build-tools/origami-build-tools');
 const path = require('path');
+const UserError = require('./utils/usererror');
 
 function sass_escape_string(str) {
 	if (str === null || typeof str === 'boolean') return JSON.stringify(str);
@@ -95,6 +96,17 @@ CssBundler.prototype = {
 
 		const buildOutputPath = installation.getDirectory();
 		const buildOutputName = 'build-' + moduleset.getMainPathOverridesIdentifier() + '-' + opts.brand + '.css';
+
+		const components = yield installation.listAllOrigamiComponents();
+
+		for (const [name, properties] of Object.entries(components)) {
+			const manifest = yield installation.getOrigamiManifest(name);
+			const specVersion = manifest.origamiVersion;
+			if (specVersion > 1) {
+				const componentVersion = properties.version;
+				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+			}
+		}
 
 		const mainFilePromise = this.createMainFile(installation, moduleset, mainSassPath, opts);
 		const shrinkwrapPromise = this.createShrinkWrapComment(installation, moduleset, opts);

--- a/lib/democompiler.js
+++ b/lib/democompiler.js
@@ -8,6 +8,7 @@ const gulp = require('gulp');
 const obt = require('./build-tools/origami-build-tools');
 const CompileError = require('./utils/compileerror');
 const hostnames = require('./utils/hostnames');
+const UserError = require('./utils/usererror');
 
 function DemoCompiler(options) {
 	this.options = options || {};
@@ -19,6 +20,17 @@ DemoCompiler.prototype = {
 
 	getContent: Q.async(function* (installation, moduleset, options) {
 		const installedModules = yield installation.list(moduleset);
+		const components = yield installation.listAllOrigamiComponents();
+
+		for (const [name, properties] of Object.entries(components)) {
+			const manifest = yield installation.getOrigamiManifest(name);
+			const specVersion = manifest.origamiVersion;
+			if (specVersion > 1) {
+				const componentVersion = properties.version;
+				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+			}
+		}
+
 		options.moduleName = Object.keys(installedModules)[0];
 		options.moduleVersion = installedModules[options.moduleName].version;
 		// Checks if it's the old demo config format where demos have

--- a/lib/fileproxy.js
+++ b/lib/fileproxy.js
@@ -10,6 +10,7 @@ const cheerio = require('cheerio');
 const ModuleSet = require('./moduleset');
 const HTTPError = require('./express/httperror');
 const hostnames = require('./utils/hostnames');
+const UserError = require('./utils/usererror');
 
 function FileProxy(options) {
 	options = options || {};
@@ -110,6 +111,17 @@ FileProxy.prototype = {
 		const moduleset = new ModuleSet([fullModuleName]);
 		const componentName = moduleset.getResolvedModules()[0].endpoint.name;
 		const installation = yield this.installationManager.createInstallation(moduleset, {});
+
+		const components = yield installation.listAllOrigamiComponents();
+
+		for (const [name, properties] of Object.entries(components)) {
+			const manifest = yield installation.getOrigamiManifest(name);
+			const specVersion = manifest.origamiVersion;
+			if (specVersion > 1) {
+				const componentVersion = properties.version;
+				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+			}
+		}
 
 		const absPath = installation.getPathToComponentsFile(componentName, relPath);
 

--- a/lib/jsbundler.js
+++ b/lib/jsbundler.js
@@ -12,6 +12,7 @@ const streamCat = require('streamcat');
 
 const gulp = require('gulp');
 const obt = require('./build-tools/origami-build-tools');
+const UserError = require('./utils/usererror');
 
 function JsBundler(options) {
 	this.options = options || {};
@@ -114,6 +115,17 @@ JsBundler.prototype = {
 
 		const buildOutputPath = installation.getDirectory();
 		const buildOutputName = 'build-' + moduleset.getMainPathOverridesIdentifier() + '.js';
+
+		const components = yield installation.listAllOrigamiComponents();
+
+		for (const [name, properties] of Object.entries(components)) {
+			const manifest = yield installation.getOrigamiManifest(name);
+			const specVersion = manifest.origamiVersion;
+			if (specVersion > 1) {
+				const componentVersion = properties.version;
+				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+			}
+		}
 
 		const mainFilePromise = this.createMainFile(installation, moduleset, mainScriptPath, opts);
 		const skrinkWrapBufferPromise = this.createShrinkWrapComment(installation, moduleset, opts);

--- a/lib/middleware/outputBundle.js
+++ b/lib/middleware/outputBundle.js
@@ -62,44 +62,46 @@ module.exports = app => {
 		// this avoids short request timeouts in Heroku and other possible intermediary nodes.
 		// Also when running multiple build service nodes, this provides an opportunity to
 		// connect to a different backend that may already have the bundle in cache
-		return Promise.race([
-			bundler.getBundle(type, moduleInstallationPromise, moduleset, bundleDetails),
-			promiseTimeout(timeoutDurationMSec)
-		]).then(function (bundle) {
+		// return Promise.resolve().then(() => {
+			return Promise.race([
+				bundler.getBundle(type, moduleInstallationPromise, moduleset, bundleDetails),
+				promiseTimeout(timeoutDurationMSec)
+			]).then(function (bundle) {
 
-			// If request went via any redirects, redirect one final time to the canonical URL to enable response to be cached efficiently and avoid caching URLs containing `redirects` args
-			if (req.query.redirects) {
-				delete req.query.redirects;
-				metrics.count('routes.bundle.redirect', 1);
-				res.redirect(307, selfURL(req));
-			} else {
-				res.set({
-					'Content-Type': bundle.mimeType,
-					'Last-Modified': new Date(bundle.createdTime).toUTCString(),
-					'Cache-Control': cacheControlHeaderFromExpiry(bundle.expiryTime)
-				});
-
-				if (req.query.shrinkwrap) {
-					metrics.count('routes.bundle.serveShrinkWrapped', 1);
-				}
-				metrics.count('routes.bundle.serve', 1);
-				bundle.pipe(res).end();
-			}
-		}).catch(function (error) {
-			if (error === 'timeout') {
-				req.query.redirects = parseInt(req.query.redirects || 0, 10) + 1;
-				if ((req.query.redirects * timeoutDurationMSec) > maxBuildTimeMSec) {
-					metrics.count('routes.bundle.timeout', 1);
-					next(new CompileError('Maximum allowable build time exceeded'));
-				} else {
+				// If request went via any redirects, redirect one final time to the canonical URL to enable response to be cached efficiently and avoid caching URLs containing `redirects` args
+				if (req.query.redirects) {
+					delete req.query.redirects;
+					metrics.count('routes.bundle.redirect', 1);
 					res.redirect(307, selfURL(req));
+				} else {
+					res.set({
+						'Content-Type': bundle.mimeType,
+						'Last-Modified': new Date(bundle.createdTime).toUTCString(),
+						'Cache-Control': cacheControlHeaderFromExpiry(bundle.expiryTime)
+					});
+
+					if (req.query.shrinkwrap) {
+						metrics.count('routes.bundle.serveShrinkWrapped', 1);
+					}
+					metrics.count('routes.bundle.serve', 1);
+					bundle.pipe(res).end();
 				}
-			} else {
-				// Pass on any real errors so Express can convert them into an appropriate HTTP response
-				metrics.count('routes.bundle.error', 1);
-				next(error);
-			}
-		});
+			// });
+		}).catch(function (error) {
+				if (error === 'timeout') {
+					req.query.redirects = parseInt(req.query.redirects || 0, 10) + 1;
+					if ((req.query.redirects * timeoutDurationMSec) > maxBuildTimeMSec) {
+						metrics.count('routes.bundle.timeout', 1);
+						next(new CompileError('Maximum allowable build time exceeded'));
+					} else {
+						res.redirect(307, selfURL(req));
+					}
+				} else {
+					// Pass on any real errors so Express can convert them into an appropriate HTTP response
+					metrics.count('routes.bundle.error', 1);
+					next(error);
+				}
+			});
 	};
 
 	function selfURL(req) {

--- a/lib/middleware/outputDemo.js
+++ b/lib/middleware/outputDemo.js
@@ -37,7 +37,7 @@ const validateOnlyFtModules = (registry, moduleSet) => {
 };
 
 const validateOnlyOrigamiModules = (installation) => {
-	return installation.listDirectNoneOrigamiComponents()
+	return installation.listDirectNonOrigamiComponents()
 		.then(Object.keys)
 		.then((nonOrigamiComponents) => {
 			if (nonOrigamiComponents.length > 0) {

--- a/lib/middleware/outputFile.js
+++ b/lib/middleware/outputFile.js
@@ -5,6 +5,7 @@ const HTTPError = require('../express/httperror');
 const cacheControlHeaderFromExpiry = require('../utils/cacheControlHeaderFromExpiry');
 const FileProxy = require('../fileproxy');
 const InstallationManager = require('../installationmanager');
+const UserError = require('../utils/usererror');
 
 module.exports = app => {
 	const {metrics, options} = app.ft;
@@ -54,7 +55,7 @@ module.exports = app => {
 				});
 			}
 		}, error => {
-			if (error instanceof HTTPError) {
+			if (error instanceof HTTPError || error instanceof UserError) {
 				metrics.count('routes.files.error', 1);
 				throw error;
 			}

--- a/lib/moduleinstallation.js
+++ b/lib/moduleinstallation.js
@@ -241,12 +241,12 @@ ModuleInstallation.prototype = {
 	 *
 	 * @return {Promise}
 	 */
-	listDirectNoneOrigamiComponents() {
+	listDirectNonOrigamiComponents() {
 		return this._listFilteredComponents(this.list(), negateAsync(this.hasOrigamiManifest.bind(this)));
 	},
 
 	/**
-	 * Returns map of all directly installed non-Origami packages with their version, main files/dir, etc.
+	 * Returns map of all directly installed Origami packages with their version, main files/dir, etc.
 	 *
 	 * @return {Promise}
 	 */

--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -4,6 +4,7 @@ const Q = require('./utils/q');
 const fs = require('fs-extra');
 const tryall = require('tryall');
 const ModuleSet = require('./moduleset');
+const UserError = require('./utils/usererror');
 
 function ModuleMetadata(options) {
 	this.bundler = options.bundler;
@@ -52,6 +53,18 @@ ModuleMetadata.prototype = {
 		try {
 			const installationPromise = this.installationManager.createInstallation(moduleset, {});
 
+			const installation = yield installationPromise;
+			const components = yield installation.listAllOrigamiComponents();
+
+			for (const [name, properties] of Object.entries(components)) {
+				const manifest = yield installation.getOrigamiManifest(name);
+				const specVersion = manifest.origamiVersion;
+				if (specVersion > 1) {
+					const componentVersion = properties.version;
+					return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+				}
+			}
+
 			metadata.build.bundler = { valid:true };
 
 			// Builds CSS and JS in parallel, allows either to fail without throwing
@@ -74,7 +87,6 @@ ModuleMetadata.prototype = {
 				}.bind(this));
 			}.bind(this)));
 
-			const installation = yield installationPromise;
 
 			metadata.bowerManifest = yield installation.getBowerManifest(module.endpoint.name);
 			metadata.expiryTime = installation.expiryTime;

--- a/test/integration/v2-demos.test.js
+++ b/test/integration/v2-demos.test.js
@@ -273,4 +273,27 @@ describe('GET /v2/demos', function() {
 		});
 	});
 
+	describe('when an origami specification v2 component is requested', function() {
+		const moduleName = 'o-test-component@2.0.0-beta.1';
+		const pathName = 'main';
+
+		beforeEach(function() {
+			this.request = request(this.app)
+				.get(`/v2/demos/${moduleName}/${pathName}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function(done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function(done) {
+			this.request
+				.expect(({text}) => {
+					assert.equal(getErrorMessage(text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+				})
+				.end(done);
+		});
+	});
+
 });

--- a/test/integration/v2-files.test.js
+++ b/test/integration/v2-files.test.js
@@ -1,6 +1,13 @@
 'use strict';
 
+const assert = require('chai').assert;
 const request = require('supertest');
+const cheerio = require('cheerio');
+
+const getErrorMessage = (text) => {
+	const $ = cheerio.load(text);
+	return $('[data-test-id="error-message"]').text();
+};
 
 describe('GET /v2/files', function() {
 	this.timeout(20000);
@@ -88,6 +95,29 @@ describe('GET /v2/files', function() {
 			this.request.expect(/package .* not found/i).end(done);
 		});
 
+	});
+
+	describe('when an origami specification v2 component is requested', function() {
+		const moduleName = 'o-test-component@2.0.0-beta.1';
+		const pathName = 'main';
+
+		beforeEach(function() {
+			this.request = request(this.app)
+				.get(`/v2/files/${moduleName}/${pathName}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function(done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function(done) {
+			this.request
+				.expect(({text}) => {
+					assert.equal(getErrorMessage(text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+				})
+				.end(done);
+		});
 	});
 
 });

--- a/test/unit/lib/middleware/outputDemo.test.js
+++ b/test/unit/lib/middleware/outputDemo.test.js
@@ -61,7 +61,7 @@ describe('lib/middleware/outputDemo', function() {
 			middleware = outputDemo(origamiService.mockApp);
 
 			installationmanager.createInstallation.resolves(moduleInstallation);
-			moduleInstallation.listDirectNoneOrigamiComponents.resolves({});
+			moduleInstallation.listDirectNonOrigamiComponents.resolves({});
 		});
 
 		it('returns a middleware function', () => {
@@ -236,7 +236,7 @@ describe('lib/middleware/outputDemo', function() {
 			});
 
 			installationmanager.createInstallation.resolves(moduleInstallation);
-			moduleInstallation.listDirectNoneOrigamiComponents.resolves({});
+			moduleInstallation.listDirectNonOrigamiComponents.resolves({});
 		});
 
 		it('returns a middleware function', () => {

--- a/test/unit/mock/moduleinstallation.mock.js
+++ b/test/unit/mock/moduleinstallation.mock.js
@@ -6,7 +6,7 @@ require('sinon-as-promised');
 const ModuleInstallation = (module.exports = sinon.stub());
 
 const mockModuleInstallation = {
-    listDirectNoneOrigamiComponents: sinon.stub().resolves([]),
+    listDirectNonOrigamiComponents: sinon.stub().resolves([]),
     listAllOrigamiComponents: sinon.stub().resolves([]),
 };
 


### PR DESCRIPTION
Currently if you request an origami spec v2 component via a v2 api endpoint, the app will crash.

Instead we should return an error page indicating that the they need to use the v3 api if wanting to use a spec v2 component.