### PR TITLE
Restrict demo builds to valid semver releases (v2)

### DIFF
--- a/lib/routes/v2/demos.js
+++ b/lib/routes/v2/demos.js
@@ -3,15 +3,31 @@
 const outputDemo = require('../../middleware/outputDemo');
 const cleanBrandParameter = require('../../middleware/cleanBrandParameter');
 const defaultModuleVersions = require('../../middleware/defaultModuleVersions');
+const semver = require('semver');
+const parseModulesParameter = require('../../utils/parseModulesParameter');
+const UserError = require('../../utils/usererror');
+
+const errorForNonSemverModuleVersions = () => {
+	return (request, response, next) => {
+		const moduleVersionPairs = parseModulesParameter(request.params.fullModuleName);
+		if (!moduleVersionPairs[0] || !semver.validRange(moduleVersionPairs[0][1])) {
+			return next(new UserError('Demos may only be built for components which have been released with a valid semver version number.'));
+		}
+		next();
+	};
+};
+
 
 module.exports = app => {
 	app.get('/v2/demos/:fullModuleName/:demoName',
 		cleanBrandParameter(),
+		errorForNonSemverModuleVersions(),
 		defaultModuleVersions(),
 		outputDemo(app));
 
 	app.get('/v2/demos/:fullModuleName/:demoName/html',
 		cleanBrandParameter(),
+		errorForNonSemverModuleVersions(),
 		defaultModuleVersions(),
 		outputDemo(app, {
 			outputMinimalHtml: true

--- a/test/integration/v2-demos.test.js
+++ b/test/integration/v2-demos.test.js
@@ -36,6 +36,29 @@ describe('GET /v2/demos', function() {
 		});
 
 	});
+	describe('when a valid module and demo are requested with a valid semver range', function() {
+		const moduleName = 'o-test-component@>=1.0.30 <1.0.31';
+		const pathName = 'main';
+
+		beforeEach(function() {
+			this.request = request(this.app)
+				.get(`/v2/demos/${moduleName}/${pathName}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function(done) {
+			this.request.expect(200).end(done);
+		});
+
+		it('should respond with the expected `Content-Type` header', function(done) {
+			this.request.expect('Content-Type', 'text/html;charset=UTF-8').end(done);
+		});
+
+		it('should respond with the file contents', function(done) {
+			this.request.expect('<!DOCTYPE html>\n<html lang="en" class="o-hoverable-on ">\n<head>\n\t<meta charset="utf-8">\n\t<meta http-equiv="X-UA-Compatible" content="IE=Edge">\n\t<title>o-test-component: main demo</title>\n\t<meta name="viewport" content="initial-scale=1.0, width=device-width">\n\t<script src="//cdn.polyfill.io/v2/polyfill.min.js?features="></script>\n\t<style>body { margin: 0; } .core .o--if-js, .enhanced .o--if-no-js { display: none !important; }</style>\n\t<script>(function(d) { d.className = d.className + \' demo-js\'; })(document.documentElement);</script>\n\t<link rel="stylesheet" href="//www.ft.com/__origami/service/build/v2/bundles/css?modules=o-test-component%401.0.30%3A%2Fdemos%2Fsrc%2Fdemo.scss&amp;brand=master">\n</head>\n<body>\n<div class="o-test-component-brand"></div>\n\n<script src="//www.ft.com/__origami/service/build/v2/bundles/js?modules="></script>\n<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>\n</body>\n</html>\n').end(done);
+		});
+
+	});
 
 	describe('when a valid module and no demo is requested', function() {
 		const moduleName = 'o-test-component@v1.0.30';
@@ -268,6 +291,52 @@ describe('GET /v2/demos', function() {
 			this.request
 				.expect(({text}) => {
 					assert.equal(getErrorMessage(text), 'The modules parameter contains module names which are not origami modules: \n\t- o-test-component');
+				})
+				.end(done);
+		});
+	});
+
+	describe('when a valid module and demo are requested with a git commit hash', function () {
+		const moduleName = 'o-test-component@3efec8933c0dd75b13231ce73c5336394742255b';
+		const pathName = 'main';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(`/v2/demos/${moduleName}/${pathName}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(({ text }) => {
+					assert.equal(getErrorMessage(text), 'Demos may only be built for components which have been released with a valid semver version number.');
+				})
+				.end(done);
+		});
+	});
+
+	describe('when a valid module and demo are requested with an invalid semver version', function () {
+		const moduleName = 'o-test-component@v1.0.0$';
+		const pathName = 'main';
+
+		beforeEach(function () {
+			this.request = request(this.app)
+				.get(`/v2/demos/${moduleName}/${pathName}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 400 status', function (done) {
+			this.request.expect(400).end(done);
+		});
+
+		it('should respond with an error message', function (done) {
+			this.request
+				.expect(({ text }) => {
+					assert.equal(getErrorMessage(text), 'Demos may only be built for components which have been released with a valid semver version number.');
 				})
 				.end(done);
 		});

--- a/test/integration/v2-files.test.js
+++ b/test/integration/v2-files.test.js
@@ -38,7 +38,7 @@ describe('GET /v2/files', function() {
 	});
 
 	describe('when a valid module but invalid file path (nonexistent) are requested', function() {
-		const moduleName = 'o-test-component';
+		const moduleName = 'o-test-component@1';
 		const pathName = 'NOTAFILE';
 
 		beforeEach(function() {


### PR DESCRIPTION
v2 will only build demos for components registered with the Origami
Bower Registry, all from an allow list of Github organisations.
However it is possible to fork a component on Github and open a
pull request with malicious code changes and use the git ref that
creates to build a malicious demo through the Build Service, hosted
on the ft.com domain. By restricting demo builds to valid semver
releases this is prevented.