### PR TITLE
Make build-service v3 css endpoint work for non o- prefixed components

### DIFF
--- a/lib/middleware/v3/createEntryFileSass.js
+++ b/lib/middleware/v3/createEntryFileSass.js
@@ -21,7 +21,7 @@ async function createEntryFileSass(installationDirectory, components, brand, sys
 	for (const name of componentNames) {
 		const importComponent = `@import "${name}";`;
 		let include = '';
-		if (name.startsWith('@financial-times/o-')) {
+		if (name.startsWith('@financial-times/')) {
 			const includeName = camelCase(name.substring('@financial-times/'.length));
 			include = `@include ${includeName}();`;
 		}


### PR DESCRIPTION
This resolves https://github.com/Financial-Times/origami-build-service/issues/454