### PR TITLE
Add "o-three-sixty" to the v2 bundle allow list.

### DIFF
--- a/lib/data/v2-module-allow-list.json
+++ b/lib/data/v2-module-allow-list.json
@@ -12,6 +12,7 @@
     "n-swg",
     "sass-mq",
     "superstore-sync",
+    "o-three-sixty",
 
     "o-ads",
     "o-ads-embed",


### PR DESCRIPTION
It was missed when searching Splunk for modules requested within
the last 2 months, but has had a request recently. This may be
because success logs are sampled.

"o-three-sixty":
https://github.com/ftlabs/o-three-sixty

Related issue:
https://github.com/Financial-Times/origami-build-service/issues/455