### PR TITLE
OBS v2: Allow the `latest` demos of a component to be returned

### DIFF
--- a/lib/routes/v2/demos.js
+++ b/lib/routes/v2/demos.js
@@ -10,8 +10,14 @@ const UserError = require('../../utils/usererror');
 const errorForNonSemverModuleVersions = () => {
 	return (request, response, next) => {
 		const moduleVersionPairs = parseModulesParameter(request.params.fullModuleName);
-		if (!moduleVersionPairs[0] || !semver.validRange(moduleVersionPairs[0][1])) {
-			return next(new UserError('Demos may only be built for components which have been released with a valid semver version number.'));
+		const moduleVersionPair = moduleVersionPairs[0];
+		const moduleVersion = moduleVersionPair[1] ? moduleVersionPair[1] : null;
+		const disallowedModuleVersion = !semver.validRange(moduleVersion) && moduleVersion !== 'latest';
+		if (moduleVersion && disallowedModuleVersion) {
+			return next(new UserError(
+				'Demos may only be built for components at a valid semver ' +
+				'version number or their latest release.'
+			));
 		}
 		next();
 	};

--- a/test/integration/v2-demos-html.test.js
+++ b/test/integration/v2-demos-html.test.js
@@ -343,7 +343,7 @@ describe('GET /v2/demos', function() {
 		});
 
 		it('should respond with an error message', function () {
-			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components which have been released with a valid semver version number.');
+			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components at a valid semver version number or their latest release.');
 		});
 	});
 
@@ -366,7 +366,7 @@ describe('GET /v2/demos', function() {
 		});
 
 		it('should respond with an error message', function () {
-			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components which have been released with a valid semver version number.');
+			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components at a valid semver version number or their latest release.');
 		});
 	});
 

--- a/test/integration/v2-demos.test.js
+++ b/test/integration/v2-demos.test.js
@@ -343,7 +343,7 @@ describe('GET /v2/demos', function() {
 		});
 
 		it('should respond with an error message', function () {
-			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components which have been released with a valid semver version number.');
+			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components at a valid semver version number or their latest release.');
 		});
 	});
 
@@ -366,7 +366,7 @@ describe('GET /v2/demos', function() {
 		});
 
 		it('should respond with an error message', function () {
-			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components which have been released with a valid semver version number.');
+			assert.equal(getErrorMessage(response.text), 'Demos may only be built for components at a valid semver version number or their latest release.');
 
 		});
 	});


### PR DESCRIPTION
Closes: https://github.com/Financial-Times/origami-build-service/issues/483