### PR TITLE
Fix OBS v2 endpoints given component dependencies with invalid origam…

### DIFF
--- a/lib/cssbundler.js
+++ b/lib/cssbundler.js
@@ -100,11 +100,17 @@ CssBundler.prototype = {
 		const components = yield installation.listAllOrigamiComponents();
 
 		for (const [name, properties] of Object.entries(components)) {
-			const manifest = yield installation.getOrigamiManifest(name);
-			const specVersion = manifest.origamiVersion;
-			if (specVersion > 1) {
+			let unsupportedComponent = false;
+
+			try {
+				const manifest = yield installation.getOrigamiManifest(name);
+				const specVersion = manifest.origamiVersion;
+				unsupportedComponent = specVersion > 1;
+			} catch (e) { }
+
+			if (unsupportedComponent) {
 				const componentVersion = properties.version;
-				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+				return Promise.reject(new UserError(`${name}@${componentVersion} is not an Origami v1 component, the Origami Build Service v2 CSS bundle API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
 			}
 		}
 

--- a/lib/democompiler.js
+++ b/lib/democompiler.js
@@ -23,11 +23,17 @@ DemoCompiler.prototype = {
 		const components = yield installation.listAllOrigamiComponents();
 
 		for (const [name, properties] of Object.entries(components)) {
-			const manifest = yield installation.getOrigamiManifest(name);
-			const specVersion = manifest.origamiVersion;
-			if (specVersion > 1) {
+			let unsupportedComponent = false;
+
+			try {
+				const manifest = yield installation.getOrigamiManifest(name);
+				const specVersion = manifest.origamiVersion;
+				unsupportedComponent = specVersion > 1;
+			} catch (e) { }
+
+			if (unsupportedComponent) {
 				const componentVersion = properties.version;
-				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+				return Promise.reject(new UserError(`${name}@${componentVersion} is not an Origami v1 component, the Origami Build Service v2 demos API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
 			}
 		}
 

--- a/lib/fileproxy.js
+++ b/lib/fileproxy.js
@@ -115,11 +115,18 @@ FileProxy.prototype = {
 		const components = yield installation.listAllOrigamiComponents();
 
 		for (const [name, properties] of Object.entries(components)) {
-			const manifest = yield installation.getOrigamiManifest(name);
-			const specVersion = manifest.origamiVersion;
-			if (specVersion > 1) {
+			let unsupportedComponent = false;
+			let specVersion;
+
+			try	{
+				const manifest = yield installation.getOrigamiManifest(name);
+				specVersion = manifest.origamiVersion;
+				unsupportedComponent = specVersion > 1;
+			} catch (e) {}
+
+			if (unsupportedComponent) {
 				const componentVersion = properties.version;
-				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+				return Promise.reject(new UserError(`${name}@${componentVersion} is not an Origami v1 component, the Origami Build Service v2 files API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
 			}
 		}
 

--- a/lib/jsbundler.js
+++ b/lib/jsbundler.js
@@ -119,11 +119,17 @@ JsBundler.prototype = {
 		const components = yield installation.listAllOrigamiComponents();
 
 		for (const [name, properties] of Object.entries(components)) {
-			const manifest = yield installation.getOrigamiManifest(name);
-			const specVersion = manifest.origamiVersion;
-			if (specVersion > 1) {
+			let unsupportedComponent = false;
+
+			try {
+				const manifest = yield installation.getOrigamiManifest(name);
+				const specVersion = manifest.origamiVersion;
+				unsupportedComponent = specVersion > 1;
+			} catch (e) { }
+
+			if (unsupportedComponent) {
 				const componentVersion = properties.version;
-				return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+				return Promise.reject(new UserError(`${name}@${componentVersion} is not an Origami v1 component, the Origami Build Service v2 JS bundle API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
 			}
 		}
 

--- a/lib/modulemetadata.js
+++ b/lib/modulemetadata.js
@@ -57,11 +57,17 @@ ModuleMetadata.prototype = {
 			const components = yield installation.listAllOrigamiComponents();
 
 			for (const [name, properties] of Object.entries(components)) {
-				const manifest = yield installation.getOrigamiManifest(name);
-				const specVersion = manifest.origamiVersion;
-				if (specVersion > 1) {
+				let unsupportedComponent = false;
+
+				try {
+					const manifest = yield installation.getOrigamiManifest(name);
+					const specVersion = manifest.origamiVersion;
+					unsupportedComponent = specVersion > 1;
+				} catch (e) { }
+
+				if (unsupportedComponent) {
 					const componentVersion = properties.version;
-					return Promise.reject(new UserError(`${name}@${componentVersion} is an Origami v${specVersion} component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
+					return Promise.reject(new UserError(`${name}@${componentVersion} is not an Origami v1 component, the Origami Build Service v2 module API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API`));
 				}
 			}
 

--- a/test/integration/v2-bundles-css.test.js
+++ b/test/integration/v2-bundles-css.test.js
@@ -326,7 +326,7 @@ describe('GET /v2/bundles/css', function() {
 		});
 
 		it('should respond with an error message', function() {
-			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is not an Origami v1 component, the Origami Build Service v2 CSS bundle API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
 		});
 	});
 });

--- a/test/integration/v2-bundles-js.test.js
+++ b/test/integration/v2-bundles-js.test.js
@@ -521,6 +521,6 @@ describe('when an origami specification v2 component is requested', function() {
 	});
 
 	it('should respond with an error message', function() {
-		assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+		assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is not an Origami v1 component, the Origami Build Service v2 JS bundle API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
 	});
 });

--- a/test/integration/v2-demos-html.test.js
+++ b/test/integration/v2-demos-html.test.js
@@ -433,7 +433,7 @@ describe('GET /v2/demos', function() {
 		});
 
 		it('should respond with an error message', function() {
-			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is not an Origami v1 component, the Origami Build Service v2 demos API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
 		});
 	});
 

--- a/test/integration/v2-demos.test.js
+++ b/test/integration/v2-demos.test.js
@@ -405,7 +405,7 @@ describe('GET /v2/demos', function() {
 		});
 
 		it('should respond with an error message', function() {
-			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is not an Origami v1 component, the Origami Build Service v2 demos API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
 		});
 	});
 

--- a/test/integration/v2-files.test.js
+++ b/test/integration/v2-files.test.js
@@ -42,6 +42,30 @@ describe('GET /v2/files', function() {
 
 	});
 
+	describe('when a valid module and file path are requested, but a dependency has an invalid origami.json', function() {
+		const moduleName = 'o-header@2.5.13';
+		const pathName = 'img/ft-logo.png';
+
+		/**
+		 * @type {request.Response}
+		 */
+		let response;
+		before(async function () {
+			response = await request(this.app)
+				.get(`/v2/files/${moduleName}/${pathName}`)
+				.redirects(5)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function() {
+			assert.equal(response.status, 200);
+		});
+
+		it('should respond with the expected `Content-Type` header', function() {
+			assert.deepEqual(response.headers['content-type'], 'image/png');
+		});
+	});
+
 	describe('when a valid module but invalid file path (nonexistent) are requested', function() {
 		const moduleName = 'o-test-component@1';
 		const pathName = 'NOTAFILE';
@@ -137,7 +161,7 @@ describe('GET /v2/files', function() {
 		});
 
 		it('should respond with an error message', function() {
-			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is an Origami v2 component, the Origami Build Service v2 CSS API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
+			assert.equal(getErrorMessage(response.text), 'o-test-component@2.0.0-beta.1 is not an Origami v1 component, the Origami Build Service v2 files API only supports Origami v1 components.\n\nIf you want to use Origami v2 components you will need to use the Origami Build Service v3 API');
 		});
 	});
 


### PR DESCRIPTION
…i.json

`/v2/files/o-header@2.5.13/img/ft-logo.png` currently fails as an install
of `o-viewport`, a dependency, has an invalid `origami.json` that cannot
be parsed.

Instead, when it is not possible to check if a component follows the v1 spec
due to `origami.json` issues assume that it does so not to break existing
requests.

Related PR: https://github.com/Financial-Times/origami-build-service/pull/438
Fixes: https://sentry.io/organizations/financial-times/issues/2254274035/?project=52558&query=is%3Aunresolved