### PR TITLE
Add a surrogate-key of `website` to all the documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ By origin:
 - eu
 - us
 
+All documentation pages e.g. `/v2`, `/v2/api`, `/v2/migration`, `/v3/`, `/v3/api`, `/url-updater`:
+- website
+
 All bundle pages e.g. `/v2/bundles/css`:
 - js
 - css

--- a/lib/routes/url-updater.js
+++ b/lib/routes/url-updater.js
@@ -12,6 +12,7 @@ const UserError = require('../utils/usererror');
 
 module.exports = app => {
 	app.get('/url-updater/', cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
+		response.header('Surrogate-Key', 'website');
 		response.render('url-updater', {
 			title: 'Origami Build Service',
 			navigation: request.navigation

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -5,6 +5,7 @@ const addNavigationToRequest = require('../../../middleware/add-navigation-to-re
 
 module.exports = app => {
 	app.get('/v2/docs/api', cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
+		response.header('Surrogate-Key', 'website');
 		response.render('apiv2', {
 			title: 'API Reference - Origami Build Service',
 			layoutStyle: 'o-layout--docs',

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -5,6 +5,7 @@ const addNavigationToRequest = require('../../../middleware/add-navigation-to-re
 
 module.exports = app => {
 	app.get('/v2/docs/migration', cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
+		response.header('Surrogate-Key', 'website');
 		response.render('migration', {
 			title: 'Migration Guide - Origami Build Service',
 			layoutStyle: 'o-layout--docs',

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -6,6 +6,7 @@ const addNavigationToRequest = require('../../middleware/add-navigation-to-reque
 module.exports = app => {
 	// v2 home page
 	app.get('/v2', cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
+		response.header('Surrogate-Key', 'website');
 		response.render('index', {
 			title: 'Origami Build Service',
 			layoutStyle: 'o-layout--landing',

--- a/lib/routes/v3/docs/api.js
+++ b/lib/routes/v3/docs/api.js
@@ -5,6 +5,7 @@ const addNavigationToRequest = require('../../../middleware/add-navigation-to-re
 
 module.exports = app => {
 	app.get('/v3/docs/api', cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
+		response.header('Surrogate-Key', 'website');
 		response.render('apiv3', {
 			title: 'API Reference - Origami Build Service',
 			layoutStyle: 'o-layout--docs',

--- a/lib/routes/v3/index.js
+++ b/lib/routes/v3/index.js
@@ -6,6 +6,7 @@ module.exports = app => {
 
 	// v2 home page
 	app.get('/v3', cacheControl({maxAge: '7d'}), (request, response) => {
+		response.header('Surrogate-Key', 'website');
 		response.render('index', {
 			title: 'Origami Build Service',
 			pageLayout: 'docs',

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -8,21 +8,22 @@ describe('GET /url-updater', function () {
 	this.timeout(20000);
 	this.slow(5000);
 
-	const modules = 'o-test-component@^1.0.0';
-
 	/**
 	 * @type {request.Response}
 	 */
 	let response;
 	before(async function () {
 		response = await request(this.app)
-			.post('/url-updater')
-			.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal`)
+			.get('/url-updater')
 			.set('Connection', 'close');
 	});
 
 	it('should respond with a 200 status', function () {
 		assert.equal(response.status, 200);
+	});
+
+	it('should respond with surrogate-key containing `website`', function() {
+		assert.deepEqual(response.headers['surrogate-key'], 'website');
 	});
 
 	it('should include a build service url input', function () {

--- a/test/integration/v3.test.js
+++ b/test/integration/v3.test.js
@@ -3,7 +3,7 @@
 const request = require('supertest');
 const {assert} = require('chai');
 
-describe('GET /v2', function() {
+describe('GET /v3', function() {
 	this.timeout(20000);
 	this.slow(5000);
 
@@ -13,7 +13,7 @@ describe('GET /v2', function() {
 	let response;
 	before(async function () {
 		response = await request(this.app)
-			.get('/v2')
+			.get('/v3')
 			.set('Connection', 'close');
 	});
 


### PR DESCRIPTION
This will make it simpler for us to do any type of cache purging of the html pages on the build service.