### PR TITLE
Report non-allowed shrink-wrapped modules requested in v2 bundles

### DIFF
--- a/lib/middleware/reportDisallowedModules.js
+++ b/lib/middleware/reportDisallowedModules.js
@@ -12,19 +12,40 @@ module.exports = function () {
      */
 	return (request, response, next) => {
 
-		// Used by bundle endpoints
-		for (const [name, version] of parseModulesParameter(request.query.modules)) {
-			if (!allowedModules.includes(name)) {
-				Raven.captureMessage('A module was requested via v2 of the Build Service which is not on the allowed list of modules.', {
-					level: 'warning',
-					tags: {
-						disallowed_module: true,
-						module: name,
-						version
-					},
-				});
+		// modules param: Used by bundle endpoints.
+		if(request.query.modules) {
+			for (const [name, version] of parseModulesParameter(request.query.modules)) {
+				if (!allowedModules.includes(name)) {
+					Raven.captureMessage('A module was requested via v2 of the Build Service which is not on the allowed list of modules.', {
+						level: 'warning',
+						tags: {
+							disallowed_module: true,
+							module: name,
+							version
+						},
+					});
+				}
 			}
+
 		}
+
+		// shrinkwrap param: Used by bundle endpoints.
+		if(request.query.shrinkwrap) {
+			for (const [name, version] of parseModulesParameter(request.query.shrinkwrap)) {
+				if (!allowedModules.includes(name)) {
+					Raven.captureMessage('A module was requested in the shrinkwrap parameter, via v2 of the Build Service, which is not on the allowed list of modules.', {
+						level: 'warning',
+						tags: {
+							disallowed_module: true,
+							module: name,
+							version
+						},
+					});
+				}
+			}
+
+		}
+
 		next();
 	};
 };


### PR DESCRIPTION
The shrinkwrap parameter allows code from any repository to be
bundled, skipping the allow list check. Requested modules
in both parameters should be checked.

Since v2 will be deprecated for v3 of the Build Service soon a
static allow list should be okay.

Related PR: https://github.com/Financial-Times/origami-build-service/commit/ed17062b15f1e45cea08252d4a6cf3489e136ff4
Issue: https://github.com/Financial-Times/origami-build-service/issues/455