### PR TITLE
Do not report to Sentry module/shrinkwrap allow list misses

### DIFF
--- a/lib/middleware/cleanModulesParameter.js
+++ b/lib/middleware/cleanModulesParameter.js
@@ -3,7 +3,6 @@
 const httpError = require('http-errors');
 const parseModulesParameter = require('../utils/parseModulesParameter');
 const allowedModules = require('../data/v2-module-allow-list.json');
-const Raven = require('raven');
 
 module.exports = function () {
 
@@ -32,17 +31,8 @@ module.exports = function () {
 
 			}
 
-			for (const [name, version] of parseModulesParameter(request.query.modules)) {
+			for (const [name] of parseModulesParameter(request.query.modules)) {
 				if (!allowedModules.includes(name)) {
-					Raven.captureMessage('A module was requested via v2 of the Build Service which is not on the allowed list of modules.', {
-						level: 'warning',
-						tags: {
-							disallowed_module: true,
-							module: name,
-							version
-						},
-					});
-
 					return next(
 						httpError(400, `An unrecognised component, "${name}", was included in the module parameter. An allow list of components has been added for security reasons. Please check for typos or speak to the Origami team for help.`)
 					);

--- a/lib/middleware/cleanShrinkwrapParameter.js
+++ b/lib/middleware/cleanShrinkwrapParameter.js
@@ -3,7 +3,6 @@
 const parseModulesParameter = require('../utils/parseModulesParameter');
 const allowedShrinkwrapModules = require('../data/v2-shrinkwrap-module-allow-list.json');
 const httpError = require('http-errors');
-const Raven = require('raven');
 
 module.exports = function () {
 
@@ -15,17 +14,8 @@ module.exports = function () {
 	 */
 	return (request, response, next) => {
 		if(request.query.shrinkwrap) {
-			for (const [name, version] of parseModulesParameter(request.query.shrinkwrap)) {
+			for (const [name] of parseModulesParameter(request.query.shrinkwrap)) {
 				if (!allowedShrinkwrapModules.includes(name)) {
-					Raven.captureMessage('A module was requested in the shrinkwrap parameter, via v2 of the Build Service, which is not on the allowed list of modules.', {
-						level: 'warning',
-						tags: {
-							disallowed_module: true,
-							module: name,
-							version
-						},
-					});
-
 					return next(
 						httpError(400, `An unrecognised module, "${name}", was included in the shrinkwrap parameter. An allow list of modules has been added for security reasons. Please speak to the Origami team for help.`)
 					);


### PR DESCRIPTION
We are more confident the allow list for the modules/shrinkwrap
param covers existing requests.
https://github.com/Financial-Times/origami-build-service/issues/455