### PR TITLE
import from the main.scss file and write a descriptive error if a primary mixin does not exist

### DIFF
--- a/lib/middleware/v3/createEntryFileSass.js
+++ b/lib/middleware/v3/createEntryFileSass.js
@@ -4,6 +4,18 @@ const path = require('path');
 const writeFile = require('fs').promises.writeFile;
 const {camelCase} = require('lodash');
 
+
+function generateSassInclude(componentName) {
+	const includeName = camelCase(componentName.substring('@financial-times/'.length));
+
+	return `@if not mixin-exists('${includeName}') {
+    @error 'Could not compile sass as ${componentName} does not have a primary mixin. ' +
+    'If you think this is an issue, please contact the Origami community on Slack in #origami-support. ' +
+    'If you want to learn more about what a primary mixin is, here is a link to the specification -- https://origami.ft.com/spec/v2/components/sass/#primary-mixin';
+}
+@include ${includeName}();`;
+}
+
 /**
  * @param {string} installationDirectory The directory to create the sass file within
  * @param {Object<string, string>} components The components to import within the sass file
@@ -19,13 +31,8 @@ async function createEntryFileSass(installationDirectory, components, brand, sys
 	let entryFileContents = '$o-brand: "' + brand + '";\n$system-code: "' + systemCode +'";\n';
 
 	for (const name of componentNames) {
-		const importComponent = `@import "${name}";`;
-		let include = '';
-		if (name.startsWith('@financial-times/')) {
-			const includeName = camelCase(name.substring('@financial-times/'.length));
-			include = `@include ${includeName}();`;
-		}
-
+		const importComponent = `@import "${name}/main";`;
+		const include = generateSassInclude(name);
 		entryFileContents = entryFileContents + '\n' + importComponent + '\n' + include;
 	}
 

--- a/test/unit/lib/middleware/v3/createEntryFileSass.test.js
+++ b/test/unit/lib/middleware/v3/createEntryFileSass.test.js
@@ -33,9 +33,19 @@ describe('lib/middleware/v3/createEntryFileSass', () => {
                 $o-brand: "master";
                 $system-code: "origami";
 
-                @import "@financial-times/o-grid";
+                @import "@financial-times/o-grid/main";
+                @if not mixin-exists('oGrid') {
+                    @error 'Could not compile sass as @financial-times/o-grid does not have a primary mixin. ' +
+                    'If you think this is an issue, please contact the Origami community on Slack in #origami-support. ' +
+                    'If you want to learn more about what a primary mixin is, here is a link to the specification -- https://origami.ft.com/spec/v2/components/sass/#primary-mixin';
+                }
                 @include oGrid();
-                @import "@financial-times/o-table";
+                @import "@financial-times/o-table/main";
+                @if not mixin-exists('oTable') {
+                    @error 'Could not compile sass as @financial-times/o-table does not have a primary mixin. ' +
+                    'If you think this is an issue, please contact the Origami community on Slack in #origami-support. ' +
+                    'If you want to learn more about what a primary mixin is, here is a link to the specification -- https://origami.ft.com/spec/v2/components/sass/#primary-mixin';
+                }
                 @include oTable();`
 		);
 	});


### PR DESCRIPTION
the specification states `main.scss` is the entry point file for sass, which is why we need to import that specific file. We discussed using `index.scss`, which is what build-service v3 is currently using, but we decided to stick with `main.scss` for the time being and keep `index.scss` as a option for the future because it would help us test out other future sass changes such as sass modules.

the specification also states primary mixins must exist, if they do not, we should print a message which points the user to our support channel so that we can help fix the component which is not following the specification