### PR TITLE
allow bundle requests to contain components which do not have js and/or sass

### DIFF
--- a/lib/middleware/v3/createEntryFileJavaScript.js
+++ b/lib/middleware/v3/createEntryFileJavaScript.js
@@ -1,8 +1,15 @@
 'use strict';
 
 const path = require('path');
-const writeFile = require('fs').promises.writeFile;
+const {writeFile, readFile} = require('fs').promises;
 const lodash = require('lodash');
+
+async function hasJavaScriptExport (component, directory) {
+	const location = path.join(directory, 'node_modules', component, 'package.json');
+
+	const pkg = JSON.parse(await readFile(location, { encoding: 'utf-8'}));
+	return Object.prototype.hasOwnProperty.call(pkg, 'browser');
+}
 
 /**
  * @param {string} installationDirectory
@@ -21,6 +28,10 @@ async function createEntryFileJavaScript(installationDirectory, components, call
 	entryFileContents += 'if (typeof Origami === \'undefined\') { self.Origami = {}; }';
 
 	for (const name of componentNames) {
+		const exportsJavaScript = await hasJavaScriptExport(name, installationDirectory);
+		if (exportsJavaScript === false) {
+			continue;
+		}
 		const camelCasedName = lodash.camelCase(name);
 		const importComponent = `import * as ${camelCasedName} from "${name}";`;
 		const addComponentToOrigamiGlobal = `self.Origami["${name}"] = ${camelCasedName};`;
@@ -28,7 +39,7 @@ async function createEntryFileJavaScript(installationDirectory, components, call
 		if (callback) {
 			const addComponentToComponentsVariable = `components["${name}"] = ${camelCasedName};`;
 			entryFileContents = importComponent + '\n' + entryFileContents + '\n' + addComponentToOrigamiGlobal + '\n' + addComponentToComponentsVariable;
-		}else {
+		} else {
 			entryFileContents = importComponent + '\n' + entryFileContents + '\n' + addComponentToOrigamiGlobal;
 		}
 	}

--- a/lib/middleware/v3/createEntryFileJavaScript.js
+++ b/lib/middleware/v3/createEntryFileJavaScript.js
@@ -8,7 +8,7 @@ async function hasJavaScriptExport (component, directory) {
 	const location = path.join(directory, 'node_modules', component, 'package.json');
 
 	const pkg = JSON.parse(await readFile(location, { encoding: 'utf-8'}));
-	return Object.prototype.hasOwnProperty.call(pkg, 'browser');
+	return Object.prototype.hasOwnProperty.call(pkg, 'browser') || Object.prototype.hasOwnProperty.call(pkg, 'main');
 }
 
 /**

--- a/lib/middleware/v3/createEntryFileSass.js
+++ b/lib/middleware/v3/createEntryFileSass.js
@@ -3,7 +3,16 @@
 const path = require('path');
 const writeFile = require('fs').promises.writeFile;
 const {camelCase} = require('lodash');
+const fileOpen = require('fs').open;
+const promisify = require('util').promisify;
 
+const fileExists = (file) => promisify(fileOpen)(file, 'r').then(() => true).catch(() => false);
+
+async function hasSassExport (component, directory) {
+	const location = path.join(directory, 'node_modules', component, 'main.scss');
+
+	return await fileExists(location);
+}
 
 function generateSassInclude(componentName) {
 	const includeName = camelCase(componentName.substring('@financial-times/'.length));
@@ -31,6 +40,10 @@ async function createEntryFileSass(installationDirectory, components, brand, sys
 	let entryFileContents = '$o-brand: "' + brand + '";\n$system-code: "' + systemCode +'";\n';
 
 	for (const name of componentNames) {
+		const hasSass = await hasSassExport(name, installationDirectory);
+		if (hasSass === false) {
+			continue;
+		}
 		const importComponent = `@import "${name}/main";`;
 		const include = generateSassInclude(name);
 		entryFileContents = entryFileContents + '\n' + importComponent + '\n' + include;

--- a/lib/middleware/v3/createEntryFileSass.js
+++ b/lib/middleware/v3/createEntryFileSass.js
@@ -10,7 +10,6 @@ const fileExists = (file) => promisify(fileOpen)(file, 'r').then(() => true).cat
 
 async function hasSassExport (component, directory) {
 	const location = path.join(directory, 'node_modules', component, 'main.scss');
-
 	return await fileExists(location);
 }
 

--- a/test/unit/lib/middleware/v3/createEntryFileJavaScript.test.js
+++ b/test/unit/lib/middleware/v3/createEntryFileJavaScript.test.js
@@ -20,6 +20,8 @@ describe('lib/middleware/v3/createEntryFileJavaScript', () => {
 		const location = await fs.mkdtemp('/tmp/bundle/');
 
 		const components = {
+			'@financial-times/o-colors': 'prerelease',
+			'@financial-times/o-brand': 'prerelease',
 			lodash: '^4',
 			preact: '^10.5.5',
 		};
@@ -53,6 +55,8 @@ describe('lib/middleware/v3/createEntryFileJavaScript', () => {
 		const location = await fs.mkdtemp('/tmp/bundle/');
 
 		const components = {
+			'@financial-times/o-colors': 'prerelease',
+			'@financial-times/o-brand': 'prerelease',
 			lodash: '^4',
 			preact: '^10.5.5',
 		};

--- a/test/unit/lib/middleware/v3/createEntryFileJavaScript.test.js
+++ b/test/unit/lib/middleware/v3/createEntryFileJavaScript.test.js
@@ -4,6 +4,8 @@ const fs = require('fs').promises;
 const path = require('path');
 const proclaim = require('proclaim');
 const dedent = require('dedent');
+const installDependencies = require('../../../../../lib/middleware/v3/installDependencies').installDependencies;
+
 describe('lib/middleware/v3/createEntryFileJavaScript', () => {
 	let createEntryFileJavaScript;
 
@@ -18,9 +20,15 @@ describe('lib/middleware/v3/createEntryFileJavaScript', () => {
 		const location = await fs.mkdtemp('/tmp/bundle/');
 
 		const components = {
-			lodash: '^5',
+			lodash: '^4',
 			preact: '^10.5.5',
 		};
+
+		await fs.writeFile(path.join(location, 'package.json'), JSON.stringify({
+			dependencies: components
+		}));
+
+		await installDependencies(location);
 
 		await createEntryFileJavaScript(location, components);
 
@@ -45,9 +53,15 @@ describe('lib/middleware/v3/createEntryFileJavaScript', () => {
 		const location = await fs.mkdtemp('/tmp/bundle/');
 
 		const components = {
-			lodash: '^5',
+			lodash: '^4',
 			preact: '^10.5.5',
 		};
+
+		await fs.writeFile(path.join(location, 'package.json'), JSON.stringify({
+			dependencies: components
+		}));
+
+		await installDependencies(location);
 
 		await createEntryFileJavaScript(location, components, 'start_application');
 

--- a/test/unit/lib/middleware/v3/createEntryFileSass.test.js
+++ b/test/unit/lib/middleware/v3/createEntryFileSass.test.js
@@ -4,24 +4,33 @@ const fs = require('fs').promises;
 const path = require('path');
 const proclaim = require('proclaim');
 const dedent = require('dedent');
+const installDependencies = require('../../../../../lib/middleware/v3/installDependencies').installDependencies;
 
-describe('lib/middleware/v3/createEntryFileSass', () => {
+describe('lib/middleware/v3/createEntryFileSass', function() {
+	this.timeout(20 * 1000);
 	const createEntryFileSass = require('../../../../../lib/middleware/v3/createEntryFileSass').createEntryFileSass;
 
-	it('creates a index.scss file in the specified location and with the specified brand and modules as imported and their primary mixin used', async function () {
+	it('creates a index.scss file in the specified location and with the specified brand and components as imported and their primary mixin used', async function () {
 		await fs.mkdir('/tmp/bundle/', {recursive: true});
 
 		const location = await fs.mkdtemp('/tmp/bundle/');
 
-		const modules = {
-			'@financial-times/o-table': '100.0.0-11',
-			'@financial-times/o-grid': '100.0.0-11',
+		const components = {
+			'@financial-times/o-table': 'prerelease',
+			'@financial-times/o-grid': 'prerelease',
+			'preact': '^10.5.5'
 		};
+
+		await fs.writeFile(path.join(location, 'package.json'), JSON.stringify({
+			dependencies: components
+		}));
+
+		await installDependencies(location);
 
 		const brand = 'master';
 		const systemCode = 'origami';
 
-		await createEntryFileSass(location, modules, brand, systemCode);
+		await createEntryFileSass(location, components, brand, systemCode);
 
 		const EntryFileContents = await fs.readFile(
 			path.join(location, 'index.scss'),

--- a/test/unit/lib/middleware/v3/createEntryFileSass.test.js
+++ b/test/unit/lib/middleware/v3/createEntryFileSass.test.js
@@ -17,6 +17,53 @@ describe('lib/middleware/v3/createEntryFileSass', function() {
 
 		const components = {
 			'@financial-times/o-table': 'prerelease',
+			'@financial-times/o-grid': 'prerelease'
+		};
+
+		await fs.writeFile(path.join(location, 'package.json'), JSON.stringify({
+			dependencies: components
+		}));
+
+		await installDependencies(location);
+
+		const brand = 'master';
+		const systemCode = 'origami';
+
+		await createEntryFileSass(location, components, brand, systemCode);
+
+		const EntryFileContents = await fs.readFile(
+			path.join(location, 'index.scss'),
+			'utf-8'
+		);
+		proclaim.deepStrictEqual(
+			EntryFileContents,
+			dedent`
+                $o-brand: "master";
+                $system-code: "origami";
+
+                @import "@financial-times/o-grid/main";
+                @if not mixin-exists('oGrid') {
+                    @error 'Could not compile sass as @financial-times/o-grid does not have a primary mixin. ' +
+                    'If you think this is an issue, please contact the Origami community on Slack in #origami-support. ' +
+                    'If you want to learn more about what a primary mixin is, here is a link to the specification -- https://origami.ft.com/spec/v2/components/sass/#primary-mixin';
+                }
+                @include oGrid();
+                @import "@financial-times/o-table/main";
+                @if not mixin-exists('oTable') {
+                    @error 'Could not compile sass as @financial-times/o-table does not have a primary mixin. ' +
+                    'If you think this is an issue, please contact the Origami community on Slack in #origami-support. ' +
+                    'If you want to learn more about what a primary mixin is, here is a link to the specification -- https://origami.ft.com/spec/v2/components/sass/#primary-mixin';
+                }
+                @include oTable();`
+		);
+	});
+	it('does not import a component in the index.scss file if the component has no sass', async function () {
+		await fs.mkdir('/tmp/bundle/', {recursive: true});
+
+		const location = await fs.mkdtemp('/tmp/bundle/');
+
+		const components = {
+			'@financial-times/o-table': 'prerelease',
 			'@financial-times/o-grid': 'prerelease',
 			'preact': '^10.5.5'
 		};


### PR DESCRIPTION
This is because origami component demos use a single list of dependencies to generate the script and link tags in their html, which means they regularly have a script and/or link tag which is asking for components which don't export js/sass

This wasn't noticed until now because I had not updated the origami-build-tools v11 to use the new version of the build service. 