### PR TITLE
Use the `components` query parameter for v3 urls in the URL updater

### DIFF
--- a/lib/url-updater/update-url-for-results.js
+++ b/lib/url-updater/update-url-for-results.js
@@ -8,14 +8,41 @@
 module.exports = function updateUrlForResults(url, results) {
 	const hasOnlySpecV1Components = results.every(v => v.latestOrigamiSpec === '1');
 	const minimumBuildServiceVersion = hasOnlySpecV1Components ? 2 : 3;
+
 	const updatedUrl = new URL(
 		url.toString().replace(
 			/(?<=service\/build\/v)([1-2])(?=\/)/,
 			minimumBuildServiceVersion
 		));
+
+
+	const componentParam = minimumBuildServiceVersion === 2 ? 'modules' : 'components';
+	const unsupportedComponentParam = minimumBuildServiceVersion === 2 ? 'components' : 'modules';
+	updatedUrl.searchParams.delete(unsupportedComponentParam);
 	updatedUrl.searchParams.set(
-		'modules',
+		componentParam,
 		results.map(c => `${c.name}@^${c.latestVersion}`)
 	);
+
+	// Query param order may have changed. Ensure components are listed first.
+	const brand = updatedUrl.searchParams.get('brand');
+	if (brand) {
+		updatedUrl.searchParams.delete('brand');
+		updatedUrl.searchParams.set(
+			'brand',
+			brand
+		);
+	}
+
+	// Query param order may have changed. Ensure components are listed first.
+	const systemCode = updatedUrl.searchParams.get('system_code');
+	if (systemCode) {
+		updatedUrl.searchParams.delete('system_code');
+		updatedUrl.searchParams.set(
+			'system_code',
+			systemCode
+		);
+	}
+
 	return updatedUrl;
 };

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -47,7 +47,7 @@ describe('POST /url-updater', function () {
 		before(async function () {
 			response = await request(this.app)
 				.post('/url-updater')
-				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal`)
+				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}%26brand=internal`)
 				.set('Connection', 'close');
 		});
 
@@ -71,7 +71,7 @@ describe('POST /url-updater', function () {
 		before(async function () {
 			response = await request(this.app)
 				.post('/url-updater')
-				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal`)
+				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}%26brand=internal`)
 				.set('Connection', 'close');
 		});
 
@@ -94,7 +94,7 @@ describe('POST /url-updater', function () {
 		before(async function () {
 			response = await request(this.app)
 				.post('/url-updater')
-				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal`)
+				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}%26brand=internal`)
 				.set('Connection', 'close');
 		});
 

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -57,7 +57,7 @@ describe('POST /url-updater', function () {
 
 		it('should respond with an updated build service url', function () {
 			// expect a release of v2 or later in the updated url
-			assert.match(response.text, /modules&#x3D;o-test-component@\^([2-9]|\d\d+)/);
+			assert.match(response.text, /components&#x3D;o-test-component@\^([2-9]|\d\d+)/);
 		});
 	});
 

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -86,7 +86,7 @@ describe('POST /url-updater', function () {
 
 		it('should respond with an updated build service url', function () {
 			// expect a release of v2 or later in the updated url
-			assert.match(response.text, /modules&#x3D;o-test-component@\^([2-9]|\d\d+)/);
+			assert.match(response.text, /components&#x3D;o-test-component@\^([2-9]|\d\d+)/);
 		});
 
 		it('should specify that the brand and system_code query parameters are missing', function () {

--- a/test/unit/lib/url-updater/update-url-for-results.test.js
+++ b/test/unit/lib/url-updater/update-url-for-results.test.js
@@ -45,7 +45,7 @@ describe('lib/update-url-for-results.test', () => {
 				);
 				proclaim.equal(
 					decodeURIComponent(updatedUrl.toString()),
-					'https://www.ft.com/__origami/service/build/v3/bundles/css?modules=o-test-component@^2.1.0&brand=internal'
+					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-test-component@^2.1.0&brand=internal'
 				);
 			});
 		});
@@ -58,7 +58,7 @@ describe('lib/update-url-for-results.test', () => {
 				);
 				proclaim.equal(
 					decodeURIComponent(updatedUrl.toString()),
-					'https://www.ft.com/__origami/service/build/v3/bundles/css?modules=o-example@^1.0.1,o-test-component@^2.1.0&brand=internal'
+					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0&brand=internal'
 				);
 			});
 		});


### PR DESCRIPTION
Not `modules`.

There is more work to do to make the URL updater more helpful
for v2 to v3 migrations. I just happened to spot this whilst
working on something else:
https://github.com/Financial-Times/origami-build-service/issues/518