### PR TITLE
Update URL Builder to show missing query parameters

### DIFF
--- a/lib/routes/url-updater.js
+++ b/lib/routes/url-updater.js
@@ -23,6 +23,7 @@ module.exports = app => {
 		try {
 			const url = parseBuildServiceUrl(request.body['build-service-url']);
 			const brand = url.searchParams.get('brand');
+			const systemCode = url.searchParams.get('system_code');
 			const modules = parseModulesParameter(url);
 			const results = await evaluateModules(modules);
 			const hasOutdatedComponents = results
@@ -30,6 +31,13 @@ module.exports = app => {
 			const updatedBuildServiceUrl = decodeURIComponent(
 				updateUrlForResults(url, results).toString()
 			);
+			const missingParamWarnings = [];
+			if (!brand && updatedBuildServiceUrl.includes('bundles/css')) {
+				missingParamWarnings.push('brand');
+			}
+			if (!systemCode) {
+				missingParamWarnings.push('system_code');
+			}
 			response.render('url-updater', {
 				title: 'Origami Build Service',
 				layoutStyle: '',
@@ -38,6 +46,7 @@ module.exports = app => {
 				updatedBuildServiceUrl,
 				hasOutdatedComponents,
 				brand,
+				missingParamWarnings,
 				results,
 			});
 		} catch (error) {

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -47,7 +47,7 @@ describe('POST /url-updater', function () {
 		before(async function () {
 			response = await request(this.app)
 				.post('/url-updater')
-				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal&system_code=origami`)
+				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}%26brand=internal%26system_code=origami`)
 				.set('Connection', 'close');
 		});
 

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -47,7 +47,7 @@ describe('POST /url-updater', function () {
 		before(async function () {
 			response = await request(this.app)
 				.post('/url-updater')
-				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal`)
+				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}&brand=internal&system_code=origami`)
 				.set('Connection', 'close');
 		});
 
@@ -58,6 +58,40 @@ describe('POST /url-updater', function () {
 		it('should respond with an updated build service url', function () {
 			// expect a release of v2 or later in the updated url
 			assert.match(response.text, /modules&#x3D;o-test-component@\^([2-9]|\d\d+)/);
+		});
+
+		it('should not mention missing query parameters', function () {
+			// expect a release of v2 or later in the updated url
+			assert.notInclude(response.text, 'missing query parameter');
+		});
+	});
+
+	describe('with an outdated build service url and missing parameters', function () {
+		const modules = 'o-test-component@^1.0.0';
+
+		/**
+		 * @type {request.Response}
+		 */
+		let response;
+		before(async function () {
+			response = await request(this.app)
+				.post('/url-updater')
+				.send(`build-service-url=https://www.ft.com/__origami/service/build/v2/bundles/css?modules=${modules}`)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function () {
+			assert.equal(response.status, 200);
+		});
+
+		it('should respond with an updated build service url', function () {
+			// expect a release of v2 or later in the updated url
+			assert.match(response.text, /modules&#x3D;o-test-component@\^([2-9]|\d\d+)/);
+		});
+
+		it('should specify that the brand and system_code query parameters are missing', function () {
+			// expect a release of v2 or later in the updated url
+			assert.include(response.text, 'missing query parameter');
 		});
 	});
 

--- a/views/url-updater.html
+++ b/views/url-updater.html
@@ -46,10 +46,22 @@
 			<div class="o-layout-typography">
 				{{#if hasOutdatedComponents}}
 					<h2>The Build Service URL Given Is Outdated</h2>
-					<p>The following url requests the same components but with updated version numbers:</p>
+
+					{{#if missingParamWarnings}}
+						<p>To upgrade, start by using the below Build Service url which requests the same components but with updated version numbers, and add the following missing query parameter(s) (see the <a href="https://www.ft.com/__origami/service/build/v3/docs/api">Build Service API documentation</a> for details):</p>
+						<ul>
+							{{#missingParamWarnings}}
+							<li>{{.}}</li>
+							{{/missingParamWarnings}}
+						</ul>
+					{{else}}
+						<p>To upgrade, start by using the below Build Service url which requests the same components but with updated version numbers.</p>
+					{{/if}}
+
 					<pre><code>{{updatedBuildServiceUrl}}</code></pre>
+
 					<p>
-						You may need to make changes to your project to upgrade, if there has been a major release of a component. The below table lists each requested component version along with the latest version number, and links to the components migration guides.
+						If there has been a major release of a component you may need to take additional steps to upgrade each component. The below table lists each requested component version along with the latest version number, and links to the components migration guides.
 					</p>
 					<p>
 						If you have any issues/questions the Origami team are here to help


### PR DESCRIPTION
A low-fi solution to close:
https://github.com/Financial-Times/origami-build-service/issues/518

Instructs the user if the brand or system_code query parameter is
missing, and links to the api docs.