### PR TITLE
Correct the default npm registry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following keys are required for v2 of the Build Service. They are deprecated
 
 ### Optional
 
-  * `NPM_REGISTRY_URL`: The npm Registry url to use when installing npm dependencies. Defaults to `https://registry.npmjs.com`.
+  * `NPM_REGISTRY_URL`: The npm Registry url to use when installing npm dependencies. Defaults to `https://registry.npmjs.org`.
   * `BOWER_REGISTRY_URL`: The Bower Registry url to use when installing Bower dependencies. Defaults to `http://origami-bower-registry.ft.com`.
 
 ### Headers

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const options = {
 		process.env.BOWER_REGISTRY_URL || 'http://origami-bower-registry.ft.com',
 	tempdir: `/tmp/buildservice-${process.pid}/`,
 	testHealthcheckFailure: process.env.TEST_HEALTHCHECK_FAILURE || false,
-	npmRegistryURL: process.env.NPM_REGISTRY_URL || 'https://registry.npmjs.com'
+	npmRegistryURL: process.env.NPM_REGISTRY_URL || 'https://registry.npmjs.org'
 };
 
 /**

--- a/test/assetstest.test.js
+++ b/test/assetstest.test.js
@@ -13,7 +13,7 @@ describe('assets', function(){
 	this.timeout(120*1000);
 
 	spawnTestWithTempdir('excluded has_external_dependency', function*(tempdir){
-		const moduleset = new ModuleSet(['o-colors']);
+		const moduleset = new ModuleSet(['o-colors@^5.0.0']);
 		const installation = new ModuleInstallation(moduleset, { dir:tempdir, log:log });
 
 		yield installation.install(moduleset);
@@ -24,7 +24,7 @@ describe('assets', function(){
 	});
 
 	spawnTestWithTempdir('included has_external_dependency', function*(tempdir){
-		const moduleset = new ModuleSet(['o-header']);
+		const moduleset = new ModuleSet(['o-header@^8.0.0']);
 		const installation = new ModuleInstallation(moduleset, {dir:tempdir, log:log});
 
 		yield installation.install(moduleset);

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -42,7 +42,7 @@ before(function() {
 			requestLogFormat: null,
 			graphiteApiKey: 'xxx',
 			staticBundlesDirectory: `${__dirname}/mock-static-bundles`,
-			npmRegistryURL: process.env.NPM_REGISTRY_URL || 'https://registry.npmjs.com',
+			npmRegistryURL: process.env.NPM_REGISTRY_URL || 'https://registry.npmjs.org',
 			tempdir
 		})
 			.listen()

--- a/test/unit/lib/middleware/v3/createCssBundle.test.js
+++ b/test/unit/lib/middleware/v3/createCssBundle.test.js
@@ -67,7 +67,7 @@ describe('createCssBundle', function () {
 			request.app = {
 				ft: {
 					options: {
-						npmRegistryURL: 'https://registry.npmjs.com'
+						npmRegistryURL: 'https://registry.npmjs.org'
 					}
 				}
 			};
@@ -105,7 +105,7 @@ describe('createCssBundle', function () {
 			request.app = {
 				ft: {
 					options: {
-						npmRegistryURL: 'https://registry.npmjs.com'
+						npmRegistryURL: 'https://registry.npmjs.org'
 					}
 				}
 			};
@@ -144,7 +144,7 @@ describe('createCssBundle', function () {
 			request.app = {
 				ft: {
 					options: {
-						npmRegistryURL: 'https://registry.npmjs.com'
+						npmRegistryURL: 'https://registry.npmjs.org'
 					}
 				}
 			};
@@ -181,7 +181,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -220,7 +220,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -258,7 +258,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -296,7 +296,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -334,7 +334,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -372,7 +372,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -410,7 +410,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -448,7 +448,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -487,7 +487,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -526,7 +526,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -564,7 +564,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -603,7 +603,7 @@ describe('createCssBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};

--- a/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
+++ b/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
@@ -74,7 +74,7 @@ describe('createJavaScriptBundle', function () {
 			request.app = {
 				ft: {
 					options: {
-						npmRegistryURL: 'https://registry.npmjs.com'
+						npmRegistryURL: 'https://registry.npmjs.org'
 					}
 				}
 			};
@@ -120,7 +120,7 @@ describe('createJavaScriptBundle', function () {
 			request.app = {
 				ft: {
 					options: {
-						npmRegistryURL: 'https://registry.npmjs.com'
+						npmRegistryURL: 'https://registry.npmjs.org'
 					}
 				}
 			};
@@ -156,7 +156,7 @@ describe('createJavaScriptBundle', function () {
 			request.app = {
 				ft: {
 					options: {
-						npmRegistryURL: 'https://registry.npmjs.com'
+						npmRegistryURL: 'https://registry.npmjs.org'
 					}
 				}
 			};
@@ -194,7 +194,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -234,7 +234,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -273,7 +273,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -312,7 +312,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -351,7 +351,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -390,7 +390,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -429,7 +429,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -468,7 +468,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};
@@ -508,7 +508,7 @@ describe('createJavaScriptBundle', function () {
 				request.app = {
 					ft: {
 						options: {
-							npmRegistryURL: 'https://registry.npmjs.com'
+							npmRegistryURL: 'https://registry.npmjs.org'
 						}
 					}
 				};

--- a/test/unit/lib/middleware/v3/installDependencies.test.js
+++ b/test/unit/lib/middleware/v3/installDependencies.test.js
@@ -64,7 +64,7 @@ describe('installDependencies', () => {
 		const location = await fs.mkdtemp('/tmp/bundle/');
 		await fs.writeFile(path.join(location, 'package.json'), '{"dependencies":{"preact":"^10"}}', 'utf-8');
 
-		await installDependencies(location, 'https://registry.npmjs.com');
+		await installDependencies(location, 'https://registry.npmjs.org');
 
 		proclaim.isTrue(execa.calledOnce);
 		proclaim.isTrue(execa.calledWithExactly(npm,
@@ -81,7 +81,7 @@ describe('installDependencies', () => {
 				'--strict-peer-deps',
 				'--update-notifier=false',
 				'--bin-links=false',
-				'--registry=https://registry.npmjs.com'
+				'--registry=https://registry.npmjs.org'
 			],
 			{
 				cwd: location,


### PR DESCRIPTION
At some points Origami Build Service tests started failing for me
locally as the default npm registry is set to
"https://registry.npmjs.com". According to the npm docs:

>npm is configured to use the npm public registry at
>https://registry.npmjs.org by default.

https://docs.npmjs.com/cli/v7/using-npm/registry