### PR TITLE
Fix the v3 homepage by using the correct o-layout modifier

### DIFF
--- a/lib/routes/v3/index.js
+++ b/lib/routes/v3/index.js
@@ -9,7 +9,7 @@ module.exports = app => {
 		response.header('Surrogate-Key', 'website');
 		response.render('index', {
 			title: 'Origami Build Service',
-			pageLayout: 'docs',
+			layoutStyle: 'o-layout--landing',
 			showNav: true,
 		});
 	});


### PR DESCRIPTION
Before:
![broken layout for v3 homepage](https://user-images.githubusercontent.com/1569131/123655231-b6133100-d826-11eb-94bc-d37dcb552828.png)


After
![correct layout for v3 homepage](https://user-images.githubusercontent.com/1569131/123655279-c0352f80-d826-11eb-8810-bd5aacb66516.png)
