### PR TITLE
Release v3

### DIFF
--- a/data/navigation.json
+++ b/data/navigation.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"name": "API Reference",
-			"href": "v2/docs/api",
+			"href": "v3/docs/api",
 			"current": false,
 			"subnav": true,
 			"subnavItems": [

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -4,7 +4,7 @@ module.exports = app => {
 
 	// Service home page
 	app.get('/', (request, response) => {
-		response.redirect(301, `${request.basePath}v2/`);
+		response.redirect(301, `${request.basePath}v3/`);
 	});
 
 };

--- a/lib/routes/v3/index.js
+++ b/lib/routes/v3/index.js
@@ -1,17 +1,16 @@
 'use strict';
 
 const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
+const addNavigationToRequest = require('../../middleware/add-navigation-to-request');
 
 module.exports = app => {
-
-	// v2 home page
-	app.get('/v3', cacheControl({maxAge: '7d'}), (request, response) => {
+	// v3 home page
+	app.get('/v3', cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
 		response.header('Surrogate-Key', 'website');
 		response.render('index', {
 			title: 'Origami Build Service',
 			layoutStyle: 'o-layout--landing',
-			showNav: true,
+			navigation: request.navigation
 		});
 	});
-
 };

--- a/test/integration/home.test.js
+++ b/test/integration/home.test.js
@@ -21,8 +21,8 @@ describe('GET /', function() {
 		assert.equal(response.status, 301);
 	});
 
-	it('should respond with a v2 `Location` header', function() {
-		assert.deepEqual(response.headers['location'], `${this.basepath}v2/`);
+	it('should respond with a v3 `Location` header', function() {
+		assert.deepEqual(response.headers['location'], `${this.basepath}v3/`);
 	});
 
 	it('should respond with plaintext', function() {

--- a/views/apiv3.html
+++ b/views/apiv3.html
@@ -4,16 +4,6 @@
 
 <div class="o-layout__main" data-o-component="o-syntax-highlight">
 
-    <div class="o-spacing-s6 o-message o-message--notice o-message--inner o-message--warning" data-o-component="o-message" data-o-message-close="false">
-		<div class="o-message__container">
-			<div class="o-message__content ">
-				<p class="o-message__content-main">
-				    V3 of the Build Service API is experimental and may change at any time. For production applications we recommend using the <a href="/v2/docs/api">V2 Build Service API</a>).
-				</p>
-			</div>
-		</div>
-	</div>
-
     <div class="o-layout-typography">
 
         <h1 id="api-reference">
@@ -22,7 +12,7 @@
 
         <p>
             The current version of the API is 3. It has a smaller API interface than
-            v3 for the bundle endpoints, uses a new build system for creating the
+            v2 for the bundle endpoints, uses a new build system for creating the
             bundles, and installs the components from npm instead of from Bower.
         </p>
 

--- a/views/migration.html
+++ b/views/migration.html
@@ -20,7 +20,7 @@
 
     <p>Version 3 can not bundle Origami components which follow version 1 of the Origami component specification, if you see an error related to v1 of the specification upgrade to a newer version of the component.</p>
 
-    <p>The <code>/modules</code> and <code>/files</code> endpoints have been removed. Instead of <code>/files</code> use the <code>/v3/font</code> API endpoint instead to request font files. There is no direct replacement for other component files, and direct replacement the <code>/modules</code> endpoint. Please speak to the Origami team if your project depends on either of those features.</p>
+    <p>The <code>/modules</code> and <code>/files</code> endpoints have been removed. Instead of <code>/files</code> use the <code>/v3/font</code> API endpoint instead to request font files. There is no direct replacement for other component files, and no direct replacement for the <code>/modules</code> endpoint. Please speak to the Origami team if your project depends on either of those features.</p>
 
     <h3>JS endpoint</h3>
 

--- a/views/migration.html
+++ b/views/migration.html
@@ -9,26 +9,22 @@
 
     <h2 id="v2-to-v3-migration">Migrating from v2 to v3</h2>
 
-    <p>Version 3 bundle endpoints require a <code>system_code</code> query parameter which is the [bizops system code](https://biz-ops.in.ft.com/list/Systems) for the system which is making the build service request.</p>
+    <p>Use the <a href="/url-updater">URL updater</a> to help guide you through the migration from v2 to v3.</p>
 
-    <p>Version 3 bundle endpoints changed the query parameter from <code>modules</code> to <code>components</code>.</p>
+    <p>Version 3 introduces new query parameters, and requires others which were previously optional (see the <a href="/v3/docs/api">v3 API docs<a/> for more details):</p>
+    <ul>
+        <li>A <code>system_code</code> query parameter is now required, and must be set to a valid <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</li>
+        <li>The <code>brand</code> query parameter is required for the css bundle endpoint, where once it was optional.</li>
+        <li>The <code>modules</code> query parameter for the bundles endpoints has been renamed to <code>components</code>.</li>
+    </ul>
 
     <p>Version 3 can not bundle Origami components which follow version 1 of the Origami component specification, if you see an error related to v1 of the specification upgrade to a newer version of the component.</p>
 
-    <p>Version 3 uses npm instead of Bower to install the requested components. You will need to update your Origami Build Service urls to use the npm package names instead of the bower package names for the components you are using. For most Origami components that means putting <code>@financial-times/</code>at the beginning of the name.</p>
-
-    <p>Version 3 has removed the <code>/modules</code> endpoint.</p>
-    <p>Version 3 has removed the <code>/files</code> endpoint. To request font files please use the /v3/font API endpoint</p>
-
-    <h3>CSS endpoint</h3>
-
-    <p>Version 3 no longer uses LibSass for compiling Sass and instead uses <a href="https://sass-lang.com/dart-sass">DartSass</a>.</p>
+    <p>The <code>/modules</code> and <code>/files</code> endpoints have been removed. Instead of <code>/files</code> use the <code>/v3/font</code> API endpoint instead to request font files. There is no direct replacement for other component files, and direct replacement the <code>/modules</code> endpoint. Please speak to the Origami team if your project depends on either of those features.</p>
 
     <h3>JS endpoint</h3>
 
-    <p>Version 3 no longer uses Webpack for bundling JavaScript and instead uses <a href="https://esbuild.github.io/">ESBuild</a>.</p>
-
-    <p>The <code>/bundles/js</code> endpoint has removed support for several configuration parameters which are listed below:</p>
+    <p>In addition, <code>/bundles/js</code> endpoint has removed support for several configuration parameters which are listed below:</p>
 
     <table class="o-table o-table--horizontal-lines" data-o-component="o-table">
         <thead>
@@ -56,26 +52,33 @@
             </tr>
             <tr>
                 <td><code>autoinit</code></td>
-                <td>We no longer include <a href="https://registry.origami.ft.com/components/o-autoinit@2.0.7/readme?brand=master">o-autoinit</a> by default. You will need to add it to the <code>modules</code> query parameter if you want to include it in the bundle.</td>
+                <td>We no longer include <a href="https://registry.origami.ft.com/components/o-autoinit@2.0.7/readme?brand=master">o-autoinit</a> by default. You will need to add it to the <code>components</code> query parameter if you want to include it in the bundle.</td>
             </tr>
         </tbody>
     </table>
+
+    <p>The <code>o-autoinit</code> component is no longer included in JS bundles by default. Unless your Build Service v2 request includes <code>autoinit=0</code>, which disables component initalisation, add the <a href="https://registry.origami.ft.com/components/o-autoinit/readme">latest version of o-autoinit</a> to your <code>components</code> query parameter.</p>
+
+    <h3>Example v3 migrations</h3>
 
     <table class="o-table o-table--horizontal-lines" data-o-component="o-table">
         <thead>
             <tr>
                 <th>Before</th>
                 <th>After</th>
+                <th>Description</th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <td><code>/v2/bundles/css?modules=o-table&hellip;</code></td>
-                <td><code>/v3/bundles/css?components=@financial-times/o-table&hellip;</code></td>
+                <td><code>/v2/bundles/css?modules=o-table@^8.0.0</code></td>
+                <td><code>/v3/bundles/css?components=o-table@^9.0.0&system_code=origami&brand=master</code></td>
+                <td>Added brand and system_code parameters, and upgraded o-table.</td>
             </tr>
             <tr>
-                <td><code>/v2/bundles/js?modules=o-table&hellip;</code></td>
-                <td><code>/v3/bundles/js?components=@financial-times/o-table&hellip;</code></td>
+                <td><code>/v2/bundles/js?modules=o-table@^8.0.0</code></td>
+                <td><code>/v3/bundles/js?components=o-table@^9.0.0,o-autoinit@^2.0.7&system_code=origami</code></td>
+                <td>Added the system_code parameter and o-autoinit component, and upgraded o-table.</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
- Redirect to v3 docs.
- Remove v3 experimental banner.
- Update migration guide. I've corrected some outdated parts, added
some more details, but also deleted change log items which I don't
think will require changes from projects to migrate.