### PR TITLE
Escape `script` tags in compiled demo JS.

### DIFF
--- a/lib/middleware/v3/buildDemo.js
+++ b/lib/middleware/v3/buildDemo.js
@@ -280,7 +280,7 @@ async function buildDemoHtml(buildConfig, css, js, componentName) {
 	data.oDemoDocumentClasses = buildConfig.demo.documentClasses || buildConfig.demo.bodyClasses;
 
 	data.oDemoComponentStyle = css || '';
-	data.oDemoComponentScript = js || '';
+	data.oDemoComponentScript = js ? js.replace('</script>', '<\\/script>') : '';
 
 	data.oDemoDependenciesStylePath = dependencies ?
 		`https://www.ft.com/__origami/service/build/v3/bundles/css?system_code=origami&components=${dependencies.toString()}&brand=${brand || 'master'}` :

--- a/test/integration/v3-demos.test.js
+++ b/test/integration/v3-demos.test.js
@@ -616,4 +616,32 @@ describe('GET /v3/demo', function() {
 		});
 	});
 
+
+	describe('when a demo\'s JavaScript includes a `script` tag.', function () {
+		const component = 'o-autocomplete@1.0.0';
+		const demo = 'static';
+		const system_code = 'origami';
+		const brand = 'master';
+
+		/**
+		 * @type {request.Response}
+		 */
+		let response;
+		before(async function () {
+			response = await request(this.app)
+				.get(`/v3/demo?component=${component}&demo=${demo}&system_code=${system_code}&brand=${brand}`)
+				.redirects(5)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function() {
+			assert.equal(response.status, 200);
+		});
+
+		it('should inline the JavaScript with the script tag escaped', function() {
+			assert.include(response.text, '<script>document.F=Object<\\/script>')
+			;
+		});
+	});
+
 });


### PR DESCRIPTION
Demo JS is inlined in demo HTML. When a component's JS included
a `script` tag that was inlined within the demo HTML the component
`script` tag closed the `script` tag in the demo html early. This
meant demo JS did not run and was visible as text in the demo.
To avoid that escape any closing script tag `</script>` before
injecting it into demo HTML.

This was an issue for `o-autocomplete@1.0.0`.

![Screenshot 2021-07-06 at 16 42 39](https://user-images.githubusercontent.com/10405691/124629341-4120a680-de79-11eb-9f5b-b454fa73f19a.png)
