### PR TITLE
Link to version 3 of o-autoinit

### DIFF
--- a/test/unit/lib/url-updater/update-url-for-results.test.js
+++ b/test/unit/lib/url-updater/update-url-for-results.test.js
@@ -56,7 +56,7 @@ describe('lib/update-url-for-results.test', () => {
 				);
 				proclaim.equal(
 					decodeURIComponent(updatedUrl.toString()),
-					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-test-component@^2.1.0,o-autoinit@^2.0.7&brand=internal'
+					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-test-component@^2.1.0,o-autoinit@^3.0.0&brand=internal'
 				);
 			});
 		});
@@ -69,7 +69,7 @@ describe('lib/update-url-for-results.test', () => {
 				);
 				proclaim.equal(
 					decodeURIComponent(updatedUrl.toString()),
-					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0,o-autoinit@^2.0.7&brand=internal'
+					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0,o-autoinit@^3.0.0&brand=internal'
 				);
 			});
 		});
@@ -82,7 +82,7 @@ describe('lib/update-url-for-results.test', () => {
 				);
 				proclaim.equal(
 					decodeURIComponent(updatedUrl.toString()),
-					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0,o-autoinit@^2.0.7&brand=internal'
+					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0,o-autoinit@^3.0.0&brand=internal'
 				);
 			});
 		});
@@ -95,7 +95,7 @@ describe('lib/update-url-for-results.test', () => {
 				);
 				proclaim.equal(
 					decodeURIComponent(updatedUrl.toString()),
-					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0,o-autoinit@^2.0.7&brand=internal'
+					'https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-example@^1.0.1,o-test-component@^2.1.0,o-autoinit@^3.0.0&brand=internal'
 				);
 			});
 		});

--- a/views/partials/url-updater/v2-migration.html
+++ b/views/partials/url-updater/v2-migration.html
@@ -2,7 +2,7 @@
 
 <ol>
     <li>
-        <p>To upgrade, start by using the below Origami Build Service URL which requests the same components but with updated version numbers{{#if v2AutoInit}}, and includes the latest version of <a href="https://registry.origami.ft.com/components/o-autoinit@2.0.7/readme?brand=master">o-autoinit</a>{{/if}}:</p>
+        <p>To upgrade, start by using the below Origami Build Service URL which requests the same components but with updated version numbers{{#if v2AutoInit}}, and includes the latest version of <a href="https://registry.origami.ft.com/components/o-autoinit@3/readme?brand=master">o-autoinit</a>{{/if}}:</p>
         <pre><code>{{updatedBuildServiceUrl}}</code></pre>
     </li>
     {{#if missingParamWarnings}}


### PR DESCRIPTION
We currently link to the older version of o-autoinit on the url migration page - we should be linking to version 3, which is the version that is npm-only and works with build service v3