### PR TITLE
Set the caching for post responses to /url-updater to be private

### DIFF
--- a/lib/routes/url-updater.js
+++ b/lib/routes/url-updater.js
@@ -19,8 +19,9 @@ module.exports = app => {
 		});
 	});
 
-	app.post('/url-updater/', cacheControl({ maxAge: 0 }), addNavigationToRequest(), express.urlencoded({ extended: false }), express.text(), async (request, response) => {
+	app.post('/url-updater/', addNavigationToRequest(), express.urlencoded({ extended: false }), express.text(), async (request, response) => {
 		try {
+			response.set('Cache-Control', 'max-age=0, must-revalidate, no-cache, no-store, private');
 			const url = parseBuildServiceUrl(request.body['build-service-url']);
 			const brand = url.searchParams.get('brand');
 			const systemCode = url.searchParams.get('system_code');

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -64,6 +64,13 @@ describe('POST /url-updater', function () {
 			// expect a release of v2 or later in the updated url
 			assert.notInclude(response.text, 'missing query parameter');
 		});
+
+		it('should not be cached by fastly', function () {
+			assert.deepEqual(
+				response.headers['cache-control'],
+				'max-age=0, must-revalidate, no-cache, no-store, private'
+			);
+		});
 	});
 
 	describe('with a valid build service url which contains a very outdated component request', function () {


### PR DESCRIPTION
This resolves #543.

This informs Fastly that the response should not be reused for other requests which are currently waiting for a response (A feature known as request collasping).

I  ran 1000 post requests against the production version and 1881 of those returned a cached copy of the wrong page 🙈 

I then ran 1000 post requests to the url-updater page of this branch via Fastly and none of them are returning a cached copy of the wrong page 🎉 

