### PR TITLE
Add v3 support for a placeholder `system_code` value.

### DIFF
--- a/lib/middleware/v3/parseSystemCodeParameter.js
+++ b/lib/middleware/v3/parseSystemCodeParameter.js
@@ -18,6 +18,13 @@ module.exports = {
  * @returns {Promise<string>} The system-code
  */
 async function parseSystemCodeParameter(systemCode) {
+	// Allow a placeholder system code, that is not a valid system code, for
+	// projects which are not in Biz-Ops. E.g. personal projects, tutorials,
+	// and prototypes.
+	if (systemCode === '$$$-no-bizops-system-code-$$$') {
+		return systemCode;
+	}
+
 	if (typeof systemCode !== 'string') {
 		throw new UserError('The system_code query parameter must be a string.');
 	}

--- a/test/integration/v3-bundles-js.test.js
+++ b/test/integration/v3-bundles-js.test.js
@@ -364,6 +364,25 @@ describe('GET /v3/bundles/js', function() {
 
 	});
 
+	describe('when the system_code parameter is a placeholder value', function() {
+		const componentName = 'o-test-component@2.2.9';
+		const systemCode = '$$$-no-bizops-system-code-$$$';
+
+		/**
+		 * @type {request.Response}
+		 */
+		let response;
+		before(async function () {
+			response = await request(this.app)
+				.get(`/v3/bundles/js?components=${componentName}&system_code=${systemCode}`)
+				.redirects(5)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function() {
+			assert.equal(response.status, 200);
+		});
+	});
 	describe('when the system_code parameter is an invalid value', function() {
 		const componentName = 'o-test-component@2.2.9';
 		const systemCode = '$$origami!';

--- a/test/integration/v3-demos-html.test.js
+++ b/test/integration/v3-demos-html.test.js
@@ -536,6 +536,27 @@ describe('GET /v3/demo/html', function() {
 			;
 		});
 	});
+	describe('when the request contains a placeholder system_code parameter', function() {
+		const component = 'o-test-component@2.2.9';
+		const demo = 'test-demo';
+		const system_code = '$$$-no-bizops-system-code-$$$';
+		const brand = 'master';
+
+		/**
+		 * @type {request.Response}
+		 */
+		let response;
+		before(async function () {
+			response = await request(this.app)
+				.get(`/v3/demo/html?component=${component}&demo=${demo}&system_code=${system_code}&brand=${brand}`)
+				.redirects(5)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function() {
+			assert.equal(response.status, 200);
+		});
+	});
 	describe('when the request contains an invalid system_code parameter', function() {
 		const component = 'o-test-component@2.2.9';
 		const demo = 'test-demo';

--- a/test/integration/v3-demos.test.js
+++ b/test/integration/v3-demos.test.js
@@ -538,6 +538,27 @@ describe('GET /v3/demo', function() {
 			;
 		});
 	});
+	describe('when the request contains a placeholder system_code parameter', function() {
+		const component = 'o-test-component@2.2.9';
+		const demo = 'test-demo';
+		const system_code = '$$$-no-bizops-system-code-$$$';
+		const brand = 'master';
+
+		/**
+		 * @type {request.Response}
+		 */
+		let response;
+		before(async function () {
+			response = await request(this.app)
+				.get(`/v3/demo?component=${component}&demo=${demo}&system_code=${system_code}&brand=${brand}`)
+				.redirects(5)
+				.set('Connection', 'close');
+		});
+
+		it('should respond with a 200 status', function() {
+			assert.equal(response.status, 200);
+		});
+	});
 	describe('when the request contains an invalid system_code parameter', function() {
 		const component = 'o-test-component@2.2.9';
 		const demo = 'test-demo';

--- a/test/unit/lib/middleware/v3/createCssBundle.test.js
+++ b/test/unit/lib/middleware/v3/createCssBundle.test.js
@@ -593,6 +593,35 @@ describe('createCssBundle', function () {
 		}
 	);
 	context(
+		'when given a request with a placeholder system_code parameter',
+		async () => {
+			it('it responds with css', async () => {
+				const request = httpMock.createRequest();
+				const response = httpMock.createResponse();
+				response.startTime = sinon.spy();
+				response.endTime = sinon.spy();
+				request.app = {
+					ft: {
+						options: {
+							npmRegistryURL: 'https://registry.npmjs.org'
+						}
+					}
+				};
+				request.query.components = 'o-test-component@v2.2.2';
+				request.query.brand = 'master';
+				request.query.system_code = '$$$-no-bizops-system-code-$$$';
+
+				await createCssBundle(request, response);
+
+				proclaim.deepStrictEqual(
+					response.getHeader('content-type'),
+					'text/css; charset=UTF-8'
+				);
+				proclaim.deepStrictEqual(response.statusCode, 200);
+			});
+		}
+	);
+	context(
 		'when given a request with an invalid system_code parameter',
 		async () => {
 			it('it responds with a plain text error message', async () => {

--- a/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
+++ b/test/unit/lib/middleware/v3/createJavaScriptBundle.test.js
@@ -567,6 +567,35 @@ describe('createJavaScriptBundle', function () {
 	);
 
 	context(
+		'when given a request with a placeholder system code',
+		async () => {
+			it('it responds with javascript', async () => {
+				const request = httpMock.createRequest();
+				const response = httpMock.createResponse();
+				response.startTime = sinon.spy();
+				response.endTime = sinon.spy();
+				request.app = {
+					ft: {
+						options: {
+							npmRegistryURL: 'https://registry.npmjs.org'
+						}
+					}
+				};
+				request.query.components = 'o-test-component@2.2.9';
+				request.query.system_code = '$$$-no-bizops-system-code-$$$';
+
+				await createJavaScriptBundle(request, response);
+
+				proclaim.deepStrictEqual(
+					response.getHeader('content-type'),
+					'application/javascript;charset=UTF-8'
+				);
+				proclaim.deepStrictEqual(response.statusCode, 200);
+			});
+		}
+	);
+
+	context(
 		'when given a request with an invalid system code',
 		async () => {
 			it('it responds with a plain text error message', async () => {

--- a/test/unit/lib/middleware/v3/parseSystemCodeParameters.test.js
+++ b/test/unit/lib/middleware/v3/parseSystemCodeParameters.test.js
@@ -70,4 +70,8 @@ describe('parseSystemCodeParameter', () => {
 	it('returns the system_code value if it is a valid system-code', async () => {
 		proclaim.deepStrictEqual(await parseSystemCodeParameter('origami'), 'origami');
 	});
+
+	it('returns the placeholder system_code value', async () => {
+		proclaim.deepStrictEqual(await parseSystemCodeParameter('$$$-no-bizops-system-code-$$$'), '$$$-no-bizops-system-code-$$$');
+	});
 });

--- a/views/apiv3.html
+++ b/views/apiv3.html
@@ -46,7 +46,7 @@
                 <tr id="js-system_code">
                     <td><code>system_code</code></td>
                     <td>Querystring</td>
-                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
+                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> for the system which is making the build service request. For personal projects, tutorials, prototypes, or other projects which do not have a Biz-Ops system code use <code>$$$-no-bizops-system-code-$$$</code> as a placeholder instead. Do not use the placeholder for a production system maintained by the FT, or any system where a valid <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> can be used instead - including in any tests for your project. A valid system code is important for usage attribution and technical support.</td>
                 </tr>
                 <tr id="js-callback">
                     <td><code>callback</code></td>
@@ -100,7 +100,7 @@
                 <tr id="css-system_code">
                     <td><code>system_code</code></td>
                     <td>Querystring</td>
-                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
+                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> for the system which is making the build service request. For personal projects, tutorials, prototypes, or other projects which do not have a Biz-Ops system code use <code>$$$-no-bizops-system-code-$$$</code> as a placeholder instead. Do not use the placeholder for a production system maintained by the FT, or any system where a valid <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> can be used instead - including in any tests for your project. A valid system code is important for usage attribution and technical support.</td>
                 </tr>
             </tbody>
 
@@ -147,7 +147,7 @@
                 <tr id="font-system_code">
                     <td><code>system_code</code></td>
                     <td>Querystring</td>
-                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
+                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> for the system which is making the build service request. For personal projects, tutorials, prototypes, or other projects which do not have a Biz-Ops system code use <code>$$$-no-bizops-system-code-$$$</code> as a placeholder instead. Do not use the placeholder for a production system maintained by the FT, or any system where a valid <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> can be used instead - including in any tests for your project. A valid system code is important for usage attribution and technical support.</td>
                 </tr>
             </tbody>
 
@@ -199,7 +199,7 @@
                 <tr id="demo-system_code">
                     <td><code>system_code</code></td>
                     <td>Querystring</td>
-                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">bizops system code</a> for the system which is making the build service request.</td>
+                    <td>The <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> for the system which is making the build service request. For personal projects, tutorials, prototypes, or other projects which do not have a Biz-Ops system code use <code>$$$-no-bizops-system-code-$$$</code> as a placeholder instead. Do not use the placeholder for a production system maintained by the FT, or any system where a valid <a href="https://biz-ops.in.ft.com/list/Systems">Biz-Ops system code</a> can be used instead - including in any tests for your project. A valid system code is important for usage attribution and technical support.</td>
                 </tr>
             </tbody>
 


### PR DESCRIPTION
So the Build Service may be used for personal projects, prototypes,
and tutorials.

Closes: https://github.com/Financial-Times/origami-build-service/issues/546