### PR TITLE
fallback to running npm without any --offline or --prefer-offline flags

### DIFF
--- a/lib/middleware/v3/downloadAndUnpackPackage.js
+++ b/lib/middleware/v3/downloadAndUnpackPackage.js
@@ -55,6 +55,27 @@ async function downloadFromCacheWithNetworkFallback(location, name, version, reg
 }
 
 /**
+ *
+ * Downloads the specific package version using the provided registry and inserts into the cache provided.
+ * 
+ * @param {String} location Folder location to download the package into
+ * @param {String} name The name of the package
+ * @param {String} version The version of the package
+ * @param {String} [registry] The npm Registry url to use for downloading the package from
+ * @returns {Promise<string>}
+ */
+async function downloadFromNetworkAndUpdateCache(location, name, version, registry) {
+	const {stdout} = await execa.command(
+		`${npm} pack ${name}@${version} --registry=${registry} --cache=${npmCacheLocation}`,
+		{
+			cwd: location,
+			preferLocal: false,
+			shell: true,
+		});
+	return stdout;
+}
+
+/**
  * Downloads the specific package version from the specified npm registry into the specified folder
  *
  * @param {String} location Folder location to download the package into
@@ -65,7 +86,9 @@ async function downloadFromCacheWithNetworkFallback(location, name, version, reg
  */
 async function downloadAndUnpackPackage(location, name, version, registry = 'https://registry.npmjs.org/') {
 	try {
-		const filenameOfCompressedPackage = await downloadFromCacheOnly(location, name, version, registry).catch(() => downloadFromCacheWithNetworkFallback(location, name, version, registry));
+		const filenameOfCompressedPackage = await downloadFromCacheOnly(location, name, version, registry)
+			.catch(() => downloadFromCacheWithNetworkFallback(location, name, version, registry))
+			.catch(() => downloadFromNetworkAndUpdateCache(location, name, version, registry));
 		const packageLocation = path.join(location, filenameOfCompressedPackage);
 		await decompress(packageLocation, location, {strip:1});
 	} catch (err) {

--- a/lib/middleware/v3/installDependencies.js
+++ b/lib/middleware/v3/installDependencies.js
@@ -46,6 +46,24 @@ async function downloadFromCacheWithNetworkFallback(location, registry) {
 }
 
 /**
+ * Installs the dependencies for the package.json file located at `location` using the provided
+ * registry and also inserts into the cache provided.
+ * 
+ * @param {String} location Folder location to download the package into
+ * @param {String} [registry] The npm Registry url to use for downloading the package from
+ * @returns {Promise<void>}
+ */
+async function downloadFromNetworkAndUpdateCache (location, registry) {
+	await execa.command(
+		`${npm} install --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`,
+		{
+			cwd: location,
+			preferLocal: false,
+			shell: true,
+		});
+}
+
+/**
  * Installs the dependencies for the package.json file located at `location`
  *
  * @param {String} location Folder location to run `npm install` within.
@@ -54,7 +72,9 @@ async function downloadFromCacheWithNetworkFallback(location, registry) {
  */
 async function installDependencies(location, registry = 'https://registry.npmjs.org/') {
 	try {
-		await downloadFromCacheOnly(location, registry).catch(() => downloadFromCacheWithNetworkFallback(location, registry));
+		await downloadFromCacheOnly(location, registry)
+			.catch(() => downloadFromCacheWithNetworkFallback(location, registry))
+			.catch(() => downloadFromNetworkAndUpdateCache(location, registry));
 	} catch (err) {
 		if (err.stderr.includes('E404')) {
 			const line = err.stderr.split('npm ERR!').find(line => line.includes('is not in this registry'));


### PR DESCRIPTION
it seems the documentation for --prefer-offline is not aligned with the implementation

We've seen multiple times now that when a new version of a component has been published, the build service cannot locate that version when running `npm install --prefer--offline` or `npm pack --prefer-offline` but it can find the version when run without that flag.

This commit introduces a new set of functions to use when installing a dependency. Now the installation flow goes like so:
- Try installing using the cached copy and do not attempt to use the network at all
- If that failed, try installing using the cached copy and use the network as a last resort
- If that failed, use the network first and if successful then update the cached copies