### PR TITLE
When building a demo, install all dependencies instead of only production dependencies

### DIFF
--- a/lib/middleware/v3/installDependencies.js
+++ b/lib/middleware/v3/installDependencies.js
@@ -16,9 +16,14 @@ const npmCacheLocation = path.join(appRoot.toString(), './.npm-cache');
  * @param {String} [registry] The npm Registry url to use for downloading the package from
  * @returns {Promise<void>}
  */
-async function downloadFromCacheOnly(location, registry) {
+async function downloadFromCacheOnly(location, registry, installOnlyProductionDependencies = true) {
+	let npmInstallCommand = `${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`;
+	if (installOnlyProductionDependencies) {
+		npmInstallCommand += ' --production';
+	}
+
 	await execa.command(
-		`${npm} install --offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`,
+		npmInstallCommand,
 		{
 			cwd: location,
 			preferLocal: false,
@@ -27,17 +32,21 @@ async function downloadFromCacheOnly(location, registry) {
 }
 
 /**
- * Installs the dependencies for the package.json file located at `location`using the cache provided, 
- * if any of the required packages are not in the cache then the npm client will make requests to the 
+ * Installs the dependencies for the package.json file located at `location`using the cache provided,
+ * if any of the required packages are not in the cache then the npm client will make requests to the
  * provided registry to download the missing packages.
- * 
+ *
  * @param {String} location Folder location to download the package into
  * @param {String} [registry] The npm Registry url to use for downloading the package from
  * @returns {Promise<void>}
  */
-async function downloadFromCacheWithNetworkFallback(location, registry) {
+async function downloadFromCacheWithNetworkFallback(location, registry, installOnlyProductionDependencies = true) {
+	let npmInstallCommand = `${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`;
+	if (installOnlyProductionDependencies) {
+		npmInstallCommand += ' --production';
+	}
 	await execa.command(
-		`${npm} install --prefer-offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`,
+		npmInstallCommand,
 		{
 			cwd: location,
 			preferLocal: false,
@@ -48,14 +57,18 @@ async function downloadFromCacheWithNetworkFallback(location, registry) {
 /**
  * Installs the dependencies for the package.json file located at `location` using the provided
  * registry and also inserts into the cache provided.
- * 
+ *
  * @param {String} location Folder location to download the package into
  * @param {String} [registry] The npm Registry url to use for downloading the package from
  * @returns {Promise<void>}
  */
-async function downloadFromNetworkAndUpdateCache (location, registry) {
+async function downloadFromNetworkAndUpdateCache (location, registry, installOnlyProductionDependencies = true) {
+	let npmInstallCommand = `${npm} install --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`;
+	if (installOnlyProductionDependencies) {
+		npmInstallCommand += ' --production';
+	}
 	await execa.command(
-		`${npm} install --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`,
+		npmInstallCommand,
 		{
 			cwd: location,
 			preferLocal: false,
@@ -70,11 +83,11 @@ async function downloadFromNetworkAndUpdateCache (location, registry) {
  * @param {String} [registry] The npm Registry url to use when installing the dependencies
  * @returns {Promise<void>}
  */
-async function installDependencies(location, registry = 'https://registry.npmjs.org/') {
+async function installDependencies(location, registry = 'https://registry.npmjs.org/', installOnlyProductionDependencies = true) {
 	try {
-		await downloadFromCacheOnly(location, registry)
-			.catch(() => downloadFromCacheWithNetworkFallback(location, registry))
-			.catch(() => downloadFromNetworkAndUpdateCache(location, registry));
+		await downloadFromCacheOnly(location, registry, installOnlyProductionDependencies)
+			.catch(() => downloadFromCacheWithNetworkFallback(location, registry, installOnlyProductionDependencies))
+			.catch(() => downloadFromNetworkAndUpdateCache(location, registry, installOnlyProductionDependencies));
 	} catch (err) {
 		if (err.stderr.includes('E404')) {
 			const line = err.stderr.split('npm ERR!').find(line => line.includes('is not in this registry'));

--- a/lib/middleware/v3/outputDemo.js
+++ b/lib/middleware/v3/outputDemo.js
@@ -61,7 +61,7 @@ async function retrieveDemo(brand, demoName, componentName, version, npmRegistry
 		throw new UserError(`${componentName}@${version} is not an Origami v2 component, the Origami Build Service v3 API only supports Origami v2 components.`);
 	}
 
-	await installDependencies(demoLocation, npmRegistryURL);
+	await installDependencies(demoLocation, npmRegistryURL, false);
 
 	const demoHtml = await buildDemo(demoLocation, brand, demoName, componentName, version);
 	return demoHtml;

--- a/test/unit/lib/middleware/v3/installDependencies.test.js
+++ b/test/unit/lib/middleware/v3/installDependencies.test.js
@@ -35,7 +35,7 @@ describe('installDependencies', () => {
 
 		proclaim.isTrue(execa.command.calledOnce);
 		proclaim.isTrue(execa.command.calledWithExactly(
-			`${npm} install --offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+			`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
@@ -53,7 +53,7 @@ describe('installDependencies', () => {
 
 		proclaim.isTrue(execa.command.calledOnce);
 		proclaim.isTrue(execa.command.calledWithExactly(
-			`${npm} install --offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`,
+			`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
@@ -66,7 +66,7 @@ describe('installDependencies', () => {
 
 		const location = await fs.mkdtemp('/tmp/bundle/');
 		await fs.writeFile(path.join(location, 'package.json'), '{"dependencies":{"@financial-times/o-table":"9.0.2"}}', 'utf-8');
-		
+
 		// Mimic the first call to npm failing and the second call succeeding
 		execa.command.onFirstCall().rejects().onSecondCall().resolves();
 
@@ -74,14 +74,14 @@ describe('installDependencies', () => {
 
 		proclaim.isTrue(execa.command.calledTwice);
 		proclaim.isTrue(execa.command.firstCall.calledWithExactly(
-			`${npm} install --offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+			`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
 				shell: true,
 			}));
 		proclaim.isTrue(execa.command.secondCall.calledWithExactly(
-			`${npm} install --prefer-offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+			`${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
@@ -94,7 +94,7 @@ describe('installDependencies', () => {
 
 		const location = await fs.mkdtemp('/tmp/bundle/');
 		await fs.writeFile(path.join(location, 'package.json'), '{"dependencies":{"@financial-times/o-table":"9.0.2"}}', 'utf-8');
-		
+
 		// Mimic the first call to npm failing and the second call succeeding
 		execa.command.onFirstCall().rejects().onSecondCall().rejects().onThirdCall().resolves();
 
@@ -102,14 +102,14 @@ describe('installDependencies', () => {
 
 		proclaim.isFalse(execa.command.calledTwice);
 		proclaim.isTrue(execa.command.firstCall.calledWithExactly(
-			`${npm} install --offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+			`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
 				shell: true,
 			}));
 		proclaim.isTrue(execa.command.secondCall.calledWithExactly(
-			`${npm} install --prefer-offline --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+			`${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
@@ -117,11 +117,49 @@ describe('installDependencies', () => {
 			}));
 
 		proclaim.isTrue(execa.command.thirdCall.calledWithExactly(
-			`${npm} install --production --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+			`${npm} install --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --production`,
 			{
 				cwd: location,
 				preferLocal: false,
 				shell: true,
 			}));
+	});
+
+	context('when installOnlyProductionDependencies is set to false', () => {
+		it('it installs all dependencies', async () => {
+			await fs.mkdir('/tmp/bundle/', {recursive: true});
+
+			const location = await fs.mkdtemp('/tmp/bundle/');
+			await fs.writeFile(path.join(location, 'package.json'), '{"dependencies":{"@financial-times/o-table":"9.0.2"}}', 'utf-8');
+
+			// Mimic the first call to npm failing and the second call succeeding
+			execa.command.onFirstCall().rejects().onSecondCall().rejects().onThirdCall().resolves();
+
+			await installDependencies(location, 'https://registry.npmjs.org/', false);
+
+			proclaim.isFalse(execa.command.calledTwice);
+			proclaim.isTrue(execa.command.firstCall.calledWithExactly(
+				`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+				{
+					cwd: location,
+					preferLocal: false,
+					shell: true,
+				}));
+			proclaim.isTrue(execa.command.secondCall.calledWithExactly(
+				`${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+				{
+					cwd: location,
+					preferLocal: false,
+					shell: true,
+				}));
+
+			proclaim.isTrue(execa.command.thirdCall.calledWithExactly(
+				`${npm} install --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+				{
+					cwd: location,
+					preferLocal: false,
+					shell: true,
+				}));
+		});
 	});
 });


### PR DESCRIPTION
This will enable origami component's to define their demo dependencies in the package.json.devDependencies field instead of origami.json.

This would make keeping demo dependencies up-to-date simpler to achieve and would also mean that demo dependencies would be linked in the origami monorepo - E.G. When we update the design to o-buttons, we would have all the demos for all component already using the new design without having to publish anything to npm -- something which we currently can't do as the demo dependencies are downloaded from the build-service, which means they must first be published to npm.