### PR TITLE
fix: Demo builds with devDeps in a production environment.

### DIFF
--- a/lib/middleware/v3/installDependencies.js
+++ b/lib/middleware/v3/installDependencies.js
@@ -20,6 +20,9 @@ async function downloadFromCacheOnly(location, registry, installOnlyProductionDe
 	let npmInstallCommand = `${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`;
 	if (installOnlyProductionDependencies) {
 		npmInstallCommand += ' --production';
+	} else {
+		// Install devDependencies even when the NODE_ENV environment variable is set to 'production'
+		npmInstallCommand += ' --omit';
 	}
 
 	await execa.command(
@@ -44,6 +47,9 @@ async function downloadFromCacheWithNetworkFallback(location, registry, installO
 	let npmInstallCommand = `${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`;
 	if (installOnlyProductionDependencies) {
 		npmInstallCommand += ' --production';
+	} else {
+		// Install devDependencies even when the NODE_ENV environment variable is set to 'production'
+		npmInstallCommand += ' --omit';
 	}
 	await execa.command(
 		npmInstallCommand,
@@ -66,6 +72,9 @@ async function downloadFromNetworkAndUpdateCache (location, registry, installOnl
 	let npmInstallCommand = `${npm} install --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=${registry} --cache=${npmCacheLocation}`;
 	if (installOnlyProductionDependencies) {
 		npmInstallCommand += ' --production';
+	} else {
+		// Install devDependencies even when the NODE_ENV environment variable is set to 'production'
+		npmInstallCommand += ' --omit';
 	}
 	await execa.command(
 		npmInstallCommand,

--- a/test/unit/lib/middleware/v3/installDependencies.test.js
+++ b/test/unit/lib/middleware/v3/installDependencies.test.js
@@ -139,14 +139,14 @@ describe('installDependencies', () => {
 
 			proclaim.isFalse(execa.command.calledTwice);
 			proclaim.isTrue(execa.command.firstCall.calledWithExactly(
-				`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+				`${npm} install --offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --omit`,
 				{
 					cwd: location,
 					preferLocal: false,
 					shell: true,
 				}));
 			proclaim.isTrue(execa.command.secondCall.calledWithExactly(
-				`${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+				`${npm} install --prefer-offline --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --omit`,
 				{
 					cwd: location,
 					preferLocal: false,
@@ -154,7 +154,7 @@ describe('installDependencies', () => {
 				}));
 
 			proclaim.isTrue(execa.command.thirdCall.calledWithExactly(
-				`${npm} install --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation}`,
+				`${npm} install --ignore-scripts --no-package-lock --no-audit --progress=false --fund=false --package-lock=false --strict-peer-deps --update-notifier=false --bin-links=false --registry=https://registry.npmjs.org/ --cache=${npmCacheLocation} --omit`,
 				{
 					cwd: location,
 					preferLocal: false,


### PR DESCRIPTION
Set the `omit` npm flag to install demo devDeps in production.
These are required for the component demo but not for the
component itself.

>omit
>Default: 'dev' if the NODE_ENV environment variable is set to
>'production', otherwise empty.
https://docs.npmjs.com/cli/v7/commands/npm-install#omit