### PR TITLE
correct the documentation for the v3 fonts api

### DIFF
--- a/views/apiv3.html
+++ b/views/apiv3.html
@@ -139,10 +139,15 @@
                         best matching version will be used.
                     </td>
                 </tr>
-                <tr id="font-file">
-                    <td><code>file</code></td>
+                <tr id="font-name">
+                    <td><code>font_name</code></td>
                     <td>Querystring</td>
-                    <td>The path to the file to have returned.</td>
+                    <td>The name to the font to have returned. E.G. MetricWeb-Regular</td>
+                </tr>
+                <tr id="font-format">
+                    <td><code>font_format</code></td>
+                    <td>Querystring</td>
+                    <td>The file format to return. This can be either <code>woff</code> or <code>woff2</code></td>
                 </tr>
                 <tr id="font-system_code">
                     <td><code>system_code</code></td>


### PR DESCRIPTION
The parameters are actually font_name and font_format, not `font_file`.

This is an example of a valid font api url --> https://www.ft.com/__origami/service/build/v3/font?version=1.8.0&font_name=MetricWeb-Regular&font_format=normal&system_code=$$$-no-bizops-system-code-$$$