### PR TITLE
fix: filter o-fonts-assers from v bundle requests

### DIFF
--- a/lib/middleware/removeFontsAssetsFromModulesParameter.js
+++ b/lib/middleware/removeFontsAssetsFromModulesParameter.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const parseModulesParameter = require('../utils/parseModulesParameter');
+
+module.exports = function () {
+
+	/**
+	* Middleware used to remove o-fonts-assets. This should not be required directly
+	* by JS or CSS bundles and can cause an error when Github auth fails.
+	* https://github.com/Financial-Times/origami-build-service/blob/e61068dd6b0dfa2a6159fb988a4578f9df0b549b/index.js#L35
+	*/
+	return (request, response, next) => {
+
+		// Used by demo endpoints
+		if (request.params.fullModuleName) {
+			request.params.fullModuleName = removeFontsAssets(request.params.fullModuleName);
+		}
+
+		// Used by bundle endpoints
+		if (request.query.modules) {
+			request.query.modules = removeFontsAssets(request.query.modules);
+		}
+		next();
+	};
+
+	function removeFontsAssets(value) {
+		return parseModulesParameter(value)
+			.filter(([name]) => name !== 'o-fonts-assets')
+			.map(([name, version]) => {
+				return `${name}@${version}`;
+			})
+			.join(',');
+	}
+
+};

--- a/lib/routes/v2/bundles.js
+++ b/lib/routes/v2/bundles.js
@@ -8,6 +8,7 @@ const cleanShrinkwrapParameter = require('../../middleware/cleanShrinkwrapParame
 const cleanBrandParameter = require('../../middleware/cleanBrandParameter');
 const cleanSourceParameter = require('../../middleware/cleanSourceParameter');
 const cleanExportsParameter = require('../../middleware/cleanExportsParameter');
+const removeFontsAssetsFromModulesParameter = require('../../middleware/removeFontsAssetsFromModulesParameter');
 
 module.exports = app => {
 	app.get(
@@ -15,6 +16,7 @@ module.exports = app => {
 		requireModulesParameter(),
 		cleanModulesParameter(),
 		defaultModuleVersions(),
+		removeFontsAssetsFromModulesParameter(),
 		cleanShrinkwrapParameter(),
 		cleanSourceParameter(),
 		cleanBrandParameter(),


### PR DESCRIPTION
o-fonts-assets should not be required directly by JS or CSS bundles and can cause an error when Github auth fails:
this is currently happening due to our bot account origamiserviceuser losing Github access. As future access will
be through Okta I don't expect this to be restored quickly.

o-fonts-assets is the only component I know of which is private. However other build service requests could in theory
request private repos which are not Origami components.
https://github.com/Financial-Times/origami-build-service/blob/e61068dd6b0dfa2a6159fb988a4578f9df0b549b/index.js#L35