### PR TITLE
fix: OBSv2 archive, do not set Content-Length

### DIFF
--- a/lib/middleware/archive.js
+++ b/lib/middleware/archive.js
@@ -82,7 +82,6 @@ module.exports = function (app) {
 				'Content-Type': s3Result.headers['content-type'],
 				'X-Content-Type-Options': 'nosniff',
 				'Last-Modified': s3Result.headers['last-modified'],
-				'Content-Length': s3Result.headers['content-length'],
 				// Short cache 5-10 minutes chosen during rollout. Can be made much longer.
 				'Cache-Control': 'public, max-age=300, stale-while-revalidate=600, stale-if-error=600, s-maxage=600'
 			});


### PR DESCRIPTION
Previously set based on S3 response. Inaccurate. Caused font decoding issues.