### PR TITLE
backstage: update archive metric logging

### DIFF
--- a/lib/middleware/archive.js
+++ b/lib/middleware/archive.js
@@ -55,7 +55,7 @@ module.exports = function (app) {
 			}
 
 			if(s3Result.response && s3Result.response.status === 404) {
-				metrics.count('archive.miss', 1);
+				metrics.count('archive.fallback', 1);
 				if(archiveSetting === 'fallback') {
 					return next();
 				}

--- a/lib/middleware/outputBundle.js
+++ b/lib/middleware/outputBundle.js
@@ -76,6 +76,7 @@ module.exports = app => {
 			} else {
 				const archiveSetting = process.env.ARCHIVE;
 				if(archiveSetting && archiveSetting !== 'skip') {
+					metrics.count('archive.miss', 1);
 					options.log.info(`Archive Miss: ${req.originalUrl}`);
 				}
 

--- a/lib/middleware/outputDemo.js
+++ b/lib/middleware/outputDemo.js
@@ -174,6 +174,7 @@ module.exports = (app, middlewareOptions = {}) => {
 						});
 						const archiveSetting = process.env.ARCHIVE;
 						if(archiveSetting && archiveSetting !== 'skip') {
+							metrics.count('archive.miss', 1);
 							options.log.info(`Archive Miss: ${req.originalUrl}`);
 						}
 						bundle.pipe(res).end();

--- a/lib/middleware/outputFile.js
+++ b/lib/middleware/outputFile.js
@@ -38,6 +38,7 @@ module.exports = app => {
 
 				const archiveSetting = process.env.ARCHIVE;
 				if(archiveSetting && archiveSetting !== 'skip') {
+					metrics.count('archive.miss', 1);
 					options.log.info(`Archive Miss: ${request.originalUrl}`);
 				}
 


### PR DESCRIPTION
archive.miss = a valid request which would be handled was not by the archive; archive.fallback = some request was not handled by the archive but may not have been handled anyway