### PR TITLE
feat: update v2 archive to handle cache busted urls

### DIFF
--- a/lib/middleware/archive.js
+++ b/lib/middleware/archive.js
@@ -1,31 +1,8 @@
 'use strict';
 
-const crypto = require('crypto');
 const Raven = require('raven');
 const axios = require('axios').default;
-
-const pathToFilename = path => {
-	// Same name regardless of host.
-	// https://origami-build.ft.com/[...]
-	// https://www.ft.com/__origami/service/build/[...]
-	const pathWithoutOrigin = path.replace(/^\/?__origami\/service\/build\/?/, '').replace(/^\//, '');
-	// Decode for human readability.
-	const decodedPathWithoutOrigin = decodeURIComponent(pathWithoutOrigin);
-	return decodedPathWithoutOrigin
-		// Responses for one endpoint under one directory.
-		// File for query param combination.
-		.replace(/\?/, '/?')
-		// Sanitise url. Keep select special characters for
-		// human readability.
-		.replace(/[^a-zA-Z0-9-_^,&?/]/g, '_')
-		// Remove any slash from a query param (we decoded the url, and don't want
-		// someone to manipulate the structure of our s3 bucket with a query param).
-		.replace(/(?:[?])(?:.+)?[/]/g, '_')
-		// Append hash to avoid conflicts having crudely sanitised the url.
-		// Use hash of decoded path always.
-		+ '-' +
-	crypto.createHash('md5').update(decodedPathWithoutOrigin).digest('hex');
-};
+const pathToFilename = require('../path-to-archive-filename');
 
 module.exports = function (app) {
 	const {metrics} = app.ft;

--- a/lib/path-to-archive-filename.js
+++ b/lib/path-to-archive-filename.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const crypto = require('crypto');
+
+module.exports = path => {
+	// Remove any host and unexpected query params from the path.
+	// A surprising number of pages are cache busting
+	// Build Service requests dynamically.
+	const expectedQueryParams = new Set([
+		'modules',
+		'export',
+		'autoinit',
+		'shrinkwrap',
+		'brand',
+		'source',
+	]);
+
+	// default to ft.com when no host is specified
+	const tmpURL = new URL(path, 'https://ft.com');
+	const queryParams = Array.from(tmpURL.searchParams.keys());
+	queryParams.forEach(queryParam => {
+		if(!expectedQueryParams.has(queryParam)) {
+			tmpURL.searchParams.delete(queryParam);
+		}
+	});
+
+	path = tmpURL.toString().replace(tmpURL.origin, '');
+
+	// Same name regardless of host.
+	// https://origami-build.ft.com/[...]
+	// https://www.ft.com/__origami/service/build/[...]
+	const pathWithoutOrigin = path.replace(/^\/?__origami\/service\/build\/?/, '').replace(/^\//, '');
+	// Decode for human readability.
+	const decodedPathWithoutOrigin = decodeURIComponent(pathWithoutOrigin);
+	return decodedPathWithoutOrigin
+		// Responses for one endpoint under one directory.
+		// File for query param combination.
+		.replace(/\?/, '/?')
+		// Sanitise url. Keep select special characters for
+		// human readability.
+		.replace(/[^a-zA-Z0-9-_^,&?/]/g, '_')
+		// Remove any slash from a query param (we decoded the url, and don't want
+		// someone to manipulate the structure of our s3 bucket with a query param).
+		.replace(/(?:[?])(?:.+)?[/]/g, '_')
+		// Append hash to avoid conflicts having crudely sanitised the url.
+		// Use hash of decoded path always.
+		+ '-' +
+	crypto.createHash('md5').update(decodedPathWithoutOrigin).digest('hex');
+};

--- a/lib/path-to-archive-filename.js
+++ b/lib/path-to-archive-filename.js
@@ -13,6 +13,8 @@ module.exports = path => {
 		'shrinkwrap',
 		'brand',
 		'source',
+		'callback',
+		'polyfills'
 	]);
 
 	// default to ft.com when no host is specified

--- a/scripts/archive/index.js
+++ b/scripts/archive/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const readline = require('node:readline');
-const crypto = require('node:crypto');
 const dotenv = require('dotenv');
 const { stdin: input } = require('node:process');
 const axios = require('axios').default;
 const { Upload } = require('@aws-sdk/lib-storage');
 const { S3Client, HeadObjectCommand } = require('@aws-sdk/client-s3');
+const pathToFilename = require('../../lib/path-to-archive-filename');
 
 const batchLimit = 50;
 const totalLimit = 0;
@@ -75,32 +75,6 @@ const archiveExists = async (filename) => {
 		}
 		return false;
 	}
-};
-
-const pathToFilename = path => {
-	const removeOrigin = path => {
-		const url = new URL(path);
-		return path.replace(url.origin, '');
-	};
-	// Same name regardless of host.
-	// https://origami-build.ft.com/[...]
-	// https://www.ft.com/__origami/service/build/[...]
-	const pathWithoutOrigin = removeOrigin(path).replace(/^\/?__origami\/service\/build\/?/, '').replace(/^\//, '');
-	const decodedPathWithoutOrigin = decodeURIComponent(pathWithoutOrigin);
-	// Decode for human readability.
-	return decodedPathWithoutOrigin
-		// Responses for one endpoint under one directory.
-		// File for query param combination.
-		.replace(/\?/, '/?')
-		// Sanitise url. Keep select special characters for
-		// human readability.
-		.replace(/[^a-zA-Z0-9-_^,&?/]/g, '_')
-		// Remove any slash from a query param (we decoded the url, and don't want
-		// someone to manipulate the structure of our s3 bucket with a query param).
-		.replace(/(?:[?])(?:.+)?[/]/g, '_')
-		// Append hash to avoid conflicts having crudely sanitised the url.
-		+ '-' +
-		crypto.createHash('md5').update(decodedPathWithoutOrigin).digest('hex');
 };
 
 const archive = async path => {

--- a/test/integration/v2-archive.test.js
+++ b/test/integration/v2-archive.test.js
@@ -68,7 +68,8 @@ describe('Archived routes', function() {
 					before(async function () {
 						const now = (new Date()).toISOString();
 						response = await request(this.app)
-							.get(`/v2/bundles/css?modules=o-card@%5E3.0.0&test-archive-miss=${now}`)
+							// export used to cache bust, unrecognised params are removed by the archive
+							.get(`/v2/bundles/css?modules=o-card@%5E3.0.0&export=${now.replace(/[^a-zA-Z0-9]/g, '')}`)
 							.redirects(5)
 							.set('Connection', 'close');
 					});
@@ -131,7 +132,8 @@ describe('Archived routes', function() {
 					before(async function () {
 						const now = (new Date()).toISOString();
 						response = await request(this.app)
-							.get(`/v2/bundles/js?modules=o-tracking&test-archive-miss=${now}`)
+							// export used to cache bust, unrecognised params are removed by the archive
+							.get(`/v2/bundles/js?modules=o-tracking&export=${now.replace(/[^a-zA-Z0-9]/g, '')}`)
 							.redirects(5)
 							.set('Connection', 'close');
 					});
@@ -173,7 +175,8 @@ describe('Archived routes', function() {
 					before(async function () {
 						const now = (new Date()).toISOString();
 						response = await request(this.app)
-							.get(`/v2/files/o-comments@3.5.0/src/images/comment_featured_close_quote.png?test-archive-miss=${now}`)
+							// export used to cache bust, unrecognised params are removed by the archive
+							.get(`/v2/files/o-comments@3.5.0/src/images/comment_featured_close_quote.png?export=${now.replace(/[^a-zA-Z0-9]/g, '')}`)
 							.redirects(5)
 							.set('Connection', 'close');
 					});
@@ -249,7 +252,8 @@ describe('Archived routes', function() {
 					before(async function () {
 						const now = (new Date()).toISOString();
 						response = await request(this.app)
-							.get(`/v2/bundles/css?modules=o-card@%5E3.0.0&test-archive-miss=${now}`)
+							// export used to cache bust, unrecognised params are removed by the archive
+							.get(`/v2/bundles/css?modules=o-card@%5E3.0.0&export=${now.replace(/[^a-zA-Z0-9]/g, '')}`)
 							.redirects(5)
 							.set('Connection', 'close');
 					});
@@ -327,7 +331,8 @@ describe('Archived routes', function() {
 					before(async function () {
 						const now = (new Date()).toISOString();
 						response = await request(this.app)
-							.get(`/v2/bundles/js?modules=o-tracking&test-archive-miss=${now}`)
+							// export used to cache bust, unrecognised params are removed by the archive
+							.get(`/v2/bundles/js?modules=o-tracking&export=${now.replace(/[^a-zA-Z0-9]/g, '')}`)
 							.redirects(5)
 							.set('Connection', 'close');
 					});
@@ -380,7 +385,8 @@ describe('Archived routes', function() {
 					before(async function () {
 						const now = (new Date()).toISOString();
 						response = await request(this.app)
-							.get(`/v2/files/o-comments@3.5.0/src/images/comment_featured_close_quote.png?test-archive-miss=${now}`)
+							// export used to cache bust, unrecognised params are removed by the archive
+							.get(`/v2/files/o-comments@3.5.0/src/images/comment_featured_close_quote.png?export=${now.replace(/[^a-zA-Z0-9]/g, '')}`)
 							.redirects(5)
 							.set('Connection', 'close');
 					});


### PR DESCRIPTION
Some sites are included Build Service v2 requests with a cache
busting query param. I’ve found at least 220 affected sites such as https://smg2022.ft.com and https://globalmacrooutlook2022.live.ft.com, powered by bizzabo. These sites update the cache bust on every request(!?). Instead of updating hundreds of these pages and missing others, the archive has been updated to strip all but expected query params.

Expected query params is set based on a unique list of parameter names found in all currently archived urls, minus the made up cache busting param names.