### PR TITLE
Update Surrogate-Key headers used for purging cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,26 +112,34 @@ heroku restart --app origami-build-service-eu
 
 If your change does appear then the old result may be cached by our CDN. You'll need to wait for a while, or clear the CDN cache. To clear CDN cache login to Fastly and find the [www.ft.com Fastly service](https://manage.fastly.com/configure/services/133g5BGAc00Hv4v8t0dMry). Clear a specific URL (e.g. for a documentation update) or one or more of the following [surrogate keys](https://docs.fastly.com/en/guides/getting-started-with-surrogate-keys):
 
+### Documentation Cache Purge
+
 All documentation pages e.g. `/v2`, `/v2/api`, `/v2/migration`, `/v3/`, `/v3/api`, `/url-updater`:
-- website
+- origami-build-service-website
+
+### V3 API Cache Purge
+
+All bundle pages e.g. `/v3/bundles/css`:
+- origami-build-service-v3-js
+- origami-build-service-v3-css
+
+All fonts i.e. `/v3/font`:
+- origami-build-service-v3-font
+
+All demo pages e.g. `/v3/demo`:
+- origami-build-service-v3-demo
+
+### V2 API Cache Purge
 
 All bundle pages e.g. `/v2/bundles/css`:
-- js
-- css
+- origami-build-service-v2-js
+- origami-build-service-v2-css
 
 All file pages i.e. `/v2/files`:
-- files
+- origami-build-service-v2-files
 
-All module pages i.e. `/v2/modules`:
-- modules
-
-All demo pages i.e. `/v2/demos`:
-- demos
-
-By vary headers:
-- vary-accept-encoding
-- vary-origin
-- vary-access-control-request-headers
+All demo pages e.g. `/v2/demos`:
+- origami-build-service-v2-demos
 
 ## Monitoring
 

--- a/lib/middleware/archive.js
+++ b/lib/middleware/archive.js
@@ -4,16 +4,11 @@ const Raven = require('raven');
 const axios = require('axios').default;
 const pathToFilename = require('../path-to-archive-filename');
 
-module.exports = function (app, archiveSettingOverride) {
+module.exports = function (app) {
 	const {metrics} = app.ft;
 
 	return async function outputBundle(req, res, next) {
 		try {
-			const archiveSetting = archiveSettingOverride || process.env.ARCHIVE;
-			if(!archiveSetting || archiveSetting === 'skip') {
-				return next();
-			}
-
 			const archivedFilename = pathToFilename(req.originalUrl);
 
 			let s3Result;
@@ -32,10 +27,7 @@ module.exports = function (app, archiveSettingOverride) {
 			}
 
 			if(s3Result.response && s3Result.response.status === 404) {
-				if(archiveSetting === 'fallback') {
-					metrics.count('archive.fallback', 1);
-					return next();
-				}
+				metrics.count('archive.404', 1);
 				const obsError = new Error('Origami Build Service v2 is decommissioned and the requested url has not been archived. Speak to the Origami team for support. Further information including migration guides can be found in the following post: https://origami.ft.com/blog/2021/07/01/origami-on-npm-and-how-to-migrate/');
 				obsError.status = 404;
 				return next(obsError);
@@ -44,9 +36,6 @@ module.exports = function (app, archiveSettingOverride) {
 			if(s3Result instanceof Error) {
 				metrics.count('archive.fail', 1);
 				Raven.captureException(s3Result);
-				if(archiveSetting === 'fallback') {
-					return next();
-				}
 				const obsError = new Error(`Origami Build Service v2 is decommissioned and accessing the archive has returned an error. Contact the Origami team for support. (S3 Status: ${s3Result.response.status}). Further information including migration guides can be found in the following post: https://origami.ft.com/blog/2021/07/01/origami-on-npm-and-how-to-migrate/`);
 				obsError.status = 500;
 				return next(obsError);

--- a/lib/middleware/v3/createCssBundle.js
+++ b/lib/middleware/v3/createCssBundle.js
@@ -76,6 +76,7 @@ async function resolveAfter(seconds, value) {
  */
 const createCssBundle = async (request, response) => {
 	try {
+		response.header('Surrogate-Key', 'origami-build-service-v3-css');
 		const components = parseComponentsParameter(request.query.components);
 		const brand = parseBrandParameter(request.query.brand);
 		const systemCode = await parseSystemCodeParameter(request.query.system_code);

--- a/lib/middleware/v3/createJavaScriptBundle.js
+++ b/lib/middleware/v3/createJavaScriptBundle.js
@@ -74,6 +74,7 @@ async function resolveAfter(seconds, value) {
  */
 const createJavaScriptBundle = async (request, response) => {
 	try {
+		response.header('Surrogate-Key', 'origami-build-service-v3-js');
 		// Even though we do not use the system code we want to ensure
 		// the request has one to help us when we need to communicate
 		// to any users of this API endpoint.

--- a/lib/middleware/v3/outputDemo.js
+++ b/lib/middleware/v3/outputDemo.js
@@ -99,6 +99,7 @@ async function resolveAfter(seconds, value) {
 const outputDemo = async (request, response) => {
 
 	try {
+		response.header('Surrogate-Key', 'origami-build-service-v3-demo');
 		// Even though we do not use the system code we want to ensure
 		// the request has one to help us when we need to communicate
 		// to any users of this API endpoint.

--- a/lib/middleware/v3/outputFont.js
+++ b/lib/middleware/v3/outputFont.js
@@ -85,6 +85,7 @@ async function resolveAfter(seconds, value) {
  */
 const outputFont = async (request, response) => {
 	try {
+		response.header('Surrogate-Key', 'origami-build-service-v3-font');
 		// Even though we do not use the system code we want to ensure
 		// the request has one to help us when we need to communicate
 		// to any users of this API endpoint.

--- a/lib/routes/url-updater.js
+++ b/lib/routes/url-updater.js
@@ -14,7 +14,7 @@ module.exports = app => {
 	app.get([
 		'/__origami/service/build/url-updater/',
 	 ], cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
-		response.header('Surrogate-Key', 'website');
+		response.header('Surrogate-Key', 'origami-build-service-website');
 		response.render('url-updater', {
 			title: 'Origami Build Service',
 			navigation: request.navigation

--- a/lib/routes/v2/archive.js
+++ b/lib/routes/v2/archive.js
@@ -7,30 +7,33 @@ module.exports = app => {
 		[
 			/^\/__origami\/service\/build\/v2\/files\/[^/]+\//,
 		],
-		(req, res) => {
+		(req, res, next) => {
 			res.header('Surrogate-Key', 'origami-build-service-v2-files');
+			next();
 		},
-		getFromArchive(app, 'full'),
+		getFromArchive(app),
 	);
 
 	app.get(
 		[
 			/^\/__origami\/service\/build\/v2\/bundles\/css/,
 		],
-		(req, res) => {
+		(req, res, next) => {
 			res.header('Surrogate-Key', 'origami-build-service-v2-css');
+			next();
 		},
-		getFromArchive(app, 'full'),
+		getFromArchive(app),
 	);
 
 	app.get(
 		[
 			/^\/__origami\/service\/build\/v2\/bundles\/js/,
 		],
-		(req, res) => {
+		(req, res, next) => {
 			res.header('Surrogate-Key', 'origami-build-service-v2-js');
+			next();
 		},
-		getFromArchive(app, 'full'),
+		getFromArchive(app),
 	);
 
 	app.get(
@@ -38,9 +41,10 @@ module.exports = app => {
 			'/__origami/service/build/v2/demos/:fullModuleName/:demoName',
 			'/__origami/service/build/v2/demos/:fullModuleName/:demoName/html',
 		],
-		(req, res) => {
+		(req, res, next) => {
 			res.header('Surrogate-Key', 'origami-build-service-v2-demos');
+			next();
 		},
-		getFromArchive(app, 'full'),
+		getFromArchive(app),
 	);
 };

--- a/lib/routes/v2/archive.js
+++ b/lib/routes/v2/archive.js
@@ -5,14 +5,42 @@ const getFromArchive = require('../../middleware/archive');
 module.exports = app => {
 	app.get(
 		[
-			/^\/v2\/files\/[^/]+\//,
 			/^\/__origami\/service\/build\/v2\/files\/[^/]+\//,
+		],
+		(req, res) => {
+			res.header('Surrogate-Key', 'origami-build-service-v2-files');
+		},
+		getFromArchive(app, 'full'),
+	);
 
-			/^\/__origami\/service\/build\/v2\/bundles\/(css|js)/,
+	app.get(
+		[
+			/^\/__origami\/service\/build\/v2\/bundles\/css/,
+		],
+		(req, res) => {
+			res.header('Surrogate-Key', 'origami-build-service-v2-css');
+		},
+		getFromArchive(app, 'full'),
+	);
 
+	app.get(
+		[
+			/^\/__origami\/service\/build\/v2\/bundles\/js/,
+		],
+		(req, res) => {
+			res.header('Surrogate-Key', 'origami-build-service-v2-js');
+		},
+		getFromArchive(app, 'full'),
+	);
+
+	app.get(
+		[
 			'/__origami/service/build/v2/demos/:fullModuleName/:demoName',
 			'/__origami/service/build/v2/demos/:fullModuleName/:demoName/html',
 		],
+		(req, res) => {
+			res.header('Surrogate-Key', 'origami-build-service-v2-demos');
+		},
 		getFromArchive(app, 'full'),
 	);
 };

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -7,7 +7,7 @@ module.exports = app => {
 	app.get([
 		'/__origami/service/build/v2/docs/api',
 	 ], cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
-		response.header('Surrogate-Key', 'website');
+		response.header('Surrogate-Key', 'origami-build-service-website');
 		response.render('apiv2', {
 			title: 'API Reference - Origami Build Service',
 			layoutStyle: 'o-layout--docs',

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -8,7 +8,7 @@ module.exports = app => {
 		'/v2/docs/migration',
 		'/__origami/service/build/v2/docs/migration',
 	 ], cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
-		response.header('Surrogate-Key', 'website');
+		response.header('Surrogate-Key', 'origami-build-service-website');
 		response.render('migration', {
 			title: 'Migration Guide - Origami Build Service',
 			layoutStyle: 'o-layout--docs',

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -8,7 +8,7 @@ module.exports = app => {
 	app.get([
 		'/__origami/service/build/v2',
 	 ], cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
-		response.header('Surrogate-Key', 'website');
+		response.header('Surrogate-Key', 'origami-build-service-website');
 		response.render('index', {
 			title: 'Origami Build Service',
 			layoutStyle: 'o-layout--landing',

--- a/lib/routes/v3/demos.js
+++ b/lib/routes/v3/demos.js
@@ -5,9 +5,6 @@ const outputDemo = require('../../middleware/v3/outputDemo').outputDemo;
 module.exports = app => {
 	app.get([
 		'/__origami/service/build/v3/demo',
-	 ], outputDemo);
-
-	app.get([
-		'/__origami/service/build/v3/demo/html',
+		'/__origami/service/build/v3/demo/html'
 	 ], outputDemo);
 };

--- a/lib/routes/v3/docs/api.js
+++ b/lib/routes/v3/docs/api.js
@@ -7,7 +7,7 @@ module.exports = app => {
 	app.get([
 		'/__origami/service/build/v3/docs/api',
 	 ], cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
-		response.header('Surrogate-Key', 'website');
+		response.header('Surrogate-Key', 'origami-build-service-website');
 		response.render('apiv3', {
 			title: 'API Reference - Origami Build Service',
 			layoutStyle: 'o-layout--docs',

--- a/lib/routes/v3/index.js
+++ b/lib/routes/v3/index.js
@@ -8,7 +8,7 @@ module.exports = app => {
 	app.get([
 		'/__origami/service/build/v3',
 	 ], cacheControl({ maxAge: '7d' }), addNavigationToRequest(), (request, response) => {
-		response.header('Surrogate-Key', 'website');
+		response.header('Surrogate-Key', 'origami-build-service-website');
 		response.render('index', {
 			title: 'Origami Build Service',
 			layoutStyle: 'o-layout--landing',

--- a/test/integration/url-updater.test.js
+++ b/test/integration/url-updater.test.js
@@ -23,7 +23,7 @@ describe('GET /url-updater', function () {
 	});
 
 	it('should respond with surrogate-key containing `website`', function() {
-		assert.deepEqual(response.headers['surrogate-key'], 'website');
+		assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-website');
 	});
 
 	it('should include a build service url input', function () {
@@ -291,7 +291,7 @@ describe('GET /__origami/service/build/url-updater', function () {
 	});
 
 	it('should respond with surrogate-key containing `website`', function() {
-		assert.deepEqual(response.headers['surrogate-key'], 'website');
+		assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-website');
 	});
 
 	it('should include a build service url input', function () {

--- a/test/integration/v2.test.js
+++ b/test/integration/v2.test.js
@@ -26,7 +26,7 @@ describe('GET /__origami/service/build/v2', function() {
 	});
 
 	it('should respond with surrogate-key containing `website`', function() {
-		assert.deepEqual(response.headers['surrogate-key'], 'website');
+		assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-website');
 	});
 
 	it('should respond with the Origami Build Service v3 documentation', function() {
@@ -58,7 +58,7 @@ describe('GET /__origami/service/build/v2', function() {
 	});
 
 	it('should respond with surrogate-key containing `website`', function() {
-		assert.deepEqual(response.headers['surrogate-key'], 'website');
+		assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-website');
 	});
 
 	it('should respond with the Origami Build Service v3 documentation', function() {

--- a/test/integration/v3-bundles-css.test.js
+++ b/test/integration/v3-bundles-css.test.js
@@ -32,7 +32,7 @@ describe('GET /__origami/service/build/v3/bundles/css', function() {
 		});
 
 		it('should respond with surrogate-key containing `css`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-css');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-css');
 		});
 
 		it('should respond with the expected `Content-Type` header', function() {

--- a/test/integration/v3-bundles-css.test.js
+++ b/test/integration/v3-bundles-css.test.js
@@ -31,6 +31,10 @@ describe('GET /__origami/service/build/v3/bundles/css', function() {
 			assert.deepStrictEqual(response.text, '.o-test-component{padding:.5em 1em;background-color:pink}.o-test-component:after{content:\'Hello world!  The square root of 64 is "8".\'}\n');
 		});
 
+		it('should respond with surrogate-key containing `css`', function() {
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-css');
+		});
+
 		it('should respond with the expected `Content-Type` header', function() {
 			assert.deepEqual(response.headers['content-type'], 'text/css; charset=utf-8');
 		});

--- a/test/integration/v3-bundles-js.test.js
+++ b/test/integration/v3-bundles-js.test.js
@@ -70,6 +70,10 @@ describe('GET /__origami/service/build/v3/bundles/js', function() {
 			assert.deepEqual(response.headers['content-type'], 'application/javascript; charset=utf-8');
 		});
 
+		it('should respond with surrogate-key containing `js`', function() {
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-js');
+		});
+
 		it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function() {
 			assert.deepEqual(response.headers['x-content-type-options'], 'nosniff');
 		});

--- a/test/integration/v3-bundles-js.test.js
+++ b/test/integration/v3-bundles-js.test.js
@@ -71,7 +71,7 @@ describe('GET /__origami/service/build/v3/bundles/js', function() {
 		});
 
 		it('should respond with surrogate-key containing `js`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-js');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-js');
 		});
 
 		it('should respond with the expected `X-Content-Type-Options` header set to `nosniff`', function() {

--- a/test/integration/v3-demos-html.test.js
+++ b/test/integration/v3-demos-html.test.js
@@ -32,6 +32,10 @@ describe('GET /__origami/service/build/v3/demo/html', function() {
 			assert.deepEqual(response.headers['content-type'], 'text/plain; charset=utf-8');
 		});
 
+		it('should respond with surrogate-key containing `demo`', function() {
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-demo');
+		});
+
 		it('should respond with the demo html contents', function() {
 			assert.deepEqual(response.text, '<div data-o-component="o-test-component" class="o-test-component"></div>');
 		});

--- a/test/integration/v3-demos-html.test.js
+++ b/test/integration/v3-demos-html.test.js
@@ -33,7 +33,7 @@ describe('GET /__origami/service/build/v3/demo/html', function() {
 		});
 
 		it('should respond with surrogate-key containing `demo`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-demo');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-demo');
 		});
 
 		it('should respond with the demo html contents', function() {

--- a/test/integration/v3-demos.test.js
+++ b/test/integration/v3-demos.test.js
@@ -32,6 +32,10 @@ describe('GET /__origami/service/build/v3/demo', function() {
 			assert.deepEqual(response.headers['content-type'], 'text/html; charset=utf-8');
 		});
 
+		it('should respond with surrogate-key containing `demo`', function() {
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-demo');
+		});
+
 		it('should respond with the built demo', function() {
 			assert.matchSnapshot(response.text);
 		});

--- a/test/integration/v3-demos.test.js
+++ b/test/integration/v3-demos.test.js
@@ -33,7 +33,7 @@ describe('GET /__origami/service/build/v3/demo', function() {
 		});
 
 		it('should respond with surrogate-key containing `demo`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-demo');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-demo');
 		});
 
 		it('should respond with the built demo', function() {

--- a/test/integration/v3-font.test.js
+++ b/test/integration/v3-font.test.js
@@ -29,6 +29,9 @@ describe('GET /__origami/service/build/v3/font', function () {
 		it('should respond with the expected `Content-Type` header', function () {
 			assert.equal(response.headers['content-type'], 'font/woff2');
 		});
+		it('should respond with surrogate-key containing `font`', function() {
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-font');
+		});
 	});
 
 	describe('when an invalid version is requested', function () {

--- a/test/integration/v3-font.test.js
+++ b/test/integration/v3-font.test.js
@@ -30,7 +30,7 @@ describe('GET /__origami/service/build/v3/font', function () {
 			assert.equal(response.headers['content-type'], 'font/woff2');
 		});
 		it('should respond with surrogate-key containing `font`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-font');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-font');
 		});
 	});
 

--- a/test/integration/v3.test.js
+++ b/test/integration/v3.test.js
@@ -26,7 +26,7 @@ describe('GET /__origami/service/build/v3', function() {
 	});
 
 	it('should respond with surrogate-key containing `website`', function() {
-		assert.deepEqual(response.headers['surrogate-key'], 'website');
+		assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-website');
 	});
 
 	it('should respond with the Origami Build Service v3 documentation', function() {
@@ -58,7 +58,7 @@ describe('GET/__origami/service/build /v3', function() {
 	});
 
 	it('should respond with surrogate-key containing `website`', function() {
-		assert.deepEqual(response.headers['surrogate-key'], 'website');
+		assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-website');
 	});
 
 	it('should respond with the Origami Build Service v3 documentation', function() {


### PR DESCRIPTION
The [Surrogate-Key header allows us to purge](https://docs.fastly.com/en/guides/purging-with-surrogate-keys) a batch of urls
from our CDN.

Currently the Origami Build Service v2 Surrogate-Key header
is set by our cdn, Fastly. Here's the VCL used to configure that:
https://github.com/Financial-Times/ft.com-cdn/blob/da01b97de677f74606f7ed76533905255c536cdd/src/vcl/origami-build-service.vcl#L34

Some problems:
- VCL is less understood at the FT. This is happening outside the
Origami Build Service codebase. It's harder to reason about.
- The Fastly service is for the whole of ft.com. "website" as a surrogate
key could easily clash.
- There are no Surrogate-Key headers set for v3 bundles, fonts, or
demos, making it difficult to purge these categories of pages if
we need to.

This PR:
- Moves existing Surrogate-Key headers to the Origami Build Service
codebase, so we can remove from ft.com-cdn and simplify our VCL.
- Namespaces Surrogate-Key headers `origami-build-service-*`
- Adds Surrogate-Key headers to v3 responses.
- Updates the readme.