### PR TITLE
fix: Increase cache duration for archived assets and demos

### DIFF
--- a/lib/middleware/archive.js
+++ b/lib/middleware/archive.js
@@ -53,13 +53,15 @@ module.exports = function (app) {
 
 			metrics.count('archive.hit', 1);
 
+			const oneWeekInSeconds = 604800;
+			const oneDayInSeconds = 86400;
+			const fourWeekInSeconds = oneWeekInSeconds * 4;
 			res.set({
 				'Content-Type': s3Result.headers['content-type'],
 				'X-Content-Type-Options': 'nosniff',
 				'Last-Modified': s3Result.headers['last-modified'],
 				'Content-Length': s3Result.headers['content-length'],
-				// Short cache 5-10 minutes chosen during rollout. Can be made much longer.
-				'Cache-Control': 'public, max-age=300, stale-while-revalidate=600, stale-if-error=600, s-maxage=600'
+				'Cache-Control': `public, max-age=${oneWeekInSeconds}, stale-while-revalidate=${oneWeekInSeconds + oneDayInSeconds}, stale-if-error=${fourWeekInSeconds}`
 			});
 
 			s3Result.data.pipe(res);

--- a/lib/middleware/v3/outputDemo.js
+++ b/lib/middleware/v3/outputDemo.js
@@ -99,7 +99,6 @@ async function resolveAfter(seconds, value) {
 const outputDemo = async (request, response) => {
 
 	try {
-		response.header('Surrogate-Key', 'origami-build-service-v3-demo');
 		// Even though we do not use the system code we want to ensure
 		// the request has one to help us when we need to communicate
 		// to any users of this API endpoint.
@@ -124,6 +123,10 @@ const outputDemo = async (request, response) => {
 			response.send();
 		} else {
 			const demoHtml = result;
+			const oneDayInSeconds = 86400;
+			const oneWeekInSeconds = 604800;
+			// We are using a surrogate key to ensure we can clear demo cache for a specific component.
+			response.header('Surrogate-Key', `origami-build-service-v3-demo origami-build-service-v3-demo-${name}`);
 
 			if (request.path === '/v3/demo/html' || request.path === '/__origami/service/build/v3/demo/html') {
 				const html = extractMinimalHtml(demoHtml);
@@ -131,13 +134,13 @@ const outputDemo = async (request, response) => {
 				// which recieves the response does not try and execute it.
 				response.setHeader('Content-Type', 'text/plain;charset=UTF-8');
 				response.setHeader('X-Content-Type-Options', 'nosniff');
-				response.setHeader('Cache-Control', 'public, max-age=86400, stale-if-error=604800, stale-while-revalidate=300000');
+				response.setHeader('Cache-Control', `public, max-age=${oneWeekInSeconds}, stale-if-error=${oneWeekInSeconds * 4}, stale-while-revalidate=${oneWeekInSeconds + oneDayInSeconds}`);
 				response.status(200);
 				response.send(html);
 			} else {
 				response.setHeader('Content-Type', 'text/html;charset=UTF-8');
 				response.setHeader('X-Content-Type-Options', 'nosniff');
-				response.setHeader('Cache-Control', 'public, max-age=86400, stale-if-error=604800, stale-while-revalidate=300000');
+				response.setHeader('Cache-Control', `public, max-age=${oneWeekInSeconds}, stale-if-error=${oneWeekInSeconds * 4}, stale-while-revalidate=${oneWeekInSeconds + oneDayInSeconds}`);
 				response.status(200);
 				response.send(demoHtml);
 			}

--- a/test/integration/v3-demos-html.test.js
+++ b/test/integration/v3-demos-html.test.js
@@ -33,7 +33,7 @@ describe('GET /__origami/service/build/v3/demo/html', function() {
 		});
 
 		it('should respond with surrogate-key containing `demo`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-demo');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-demo origami-build-service-v3-demo-@financial-times/o-test-component');
 		});
 
 		it('should respond with the demo html contents', function() {

--- a/test/integration/v3-demos.test.js
+++ b/test/integration/v3-demos.test.js
@@ -33,7 +33,7 @@ describe('GET /__origami/service/build/v3/demo', function() {
 		});
 
 		it('should respond with surrogate-key containing `demo`', function() {
-			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-demo');
+			assert.deepEqual(response.headers['surrogate-key'], 'origami-build-service-v3-demo origami-build-service-v3-demo-@financial-times/o-test-component');
 		});
 
 		it('should respond with the built demo', function() {


### PR DESCRIPTION
Archived assets are unlikely to change, and neither are demos. I have introduced a more granular surrogate key so we can clear the cache for specific component demos if needed.

<img width="669" alt="Screenshot 2023-11-29 at 09 33 32" src="https://github.com/Financial-Times/origami-build-service/assets/10405691/2393a748-a8b6-478f-9b5a-d28b19904039">

