### PR TITLE
Delete temporary directories proactively [OR-455]

### DIFF
--- a/lib/middleware/v3/createCssBundle.js
+++ b/lib/middleware/v3/createCssBundle.js
@@ -42,6 +42,11 @@ async function retrieveCssBundle(components, brand, systemCode, npmRegistryURL) 
 	await createEntryFileSass(bundleLocation, components, brand, systemCode);
 	const bundle = await bundleSass(bundleLocation, 'index.scss', []);
 
+	// Free up disk space by asynchronously removing temporary install directory.
+	fs.rmdir(bundleLocation, {recursive: true}).catch((err) => {
+		Raven.captureException(err);
+	});
+
 	return bundle;
 }
 

--- a/lib/middleware/v3/createJavaScriptBundle.js
+++ b/lib/middleware/v3/createJavaScriptBundle.js
@@ -41,6 +41,12 @@ async function retrieveJavaScriptBundle(components, callback, npmRegistryURL) {
 	await createEntryFileJavaScript(bundleLocation, components, callback);
 
 	const bundle = await bundleJavascript(path.join(bundleLocation, 'index.js'));
+
+	// Free up disk space by asynchronously removing temporary install directory.
+	fs.rmdir(bundleLocation, {recursive: true}).catch((err) => {
+		Raven.captureException(err);
+	});
+
 	return bundle;
 }
 

--- a/lib/middleware/v3/outputDemo.js
+++ b/lib/middleware/v3/outputDemo.js
@@ -64,6 +64,12 @@ async function retrieveDemo(brand, demoName, componentName, version, npmRegistry
 	await installDependencies(demoLocation, npmRegistryURL, false);
 
 	const demoHtml = await buildDemo(demoLocation, brand, demoName, componentName, version);
+
+	// Free up disk space by asynchronously removing temporary install directory.
+	fs.rmdir(demoLocation, {recursive: true}).catch((err) => {
+		Raven.captureException(err);
+	});
+
 	return demoHtml;
 }
 


### PR DESCRIPTION
We are seeing Sentry errors from the build service "ENOSPC: no space left on device, mkdtemp /tmp/bundle/xxxx". We have seen this happen multiple times now. My assumption is that npm install is taking up available disk space. Restarting the dynos sorts it for a while, as storage is not persistent across restarts.