### PR TITLE
Remove disk-space health check

### DIFF
--- a/lib/health-checks.js
+++ b/lib/health-checks.js
@@ -84,20 +84,6 @@ function healthChecks(options) {
 				businessImpact: 'Application may not be able to serve all requests',
 				technicalSummary: 'Process is hitting the CPU harder than expected',
 				panicGuide: 'Restart the service dynos on Heroku'
-			},
-
-			// This check monitors the system disk space
-			// It will fail if usage is above the threshold
-			{
-				type: 'disk-space',
-				threshold: 90,
-				interval: 60000,
-				id: 'disk-space',
-				name: 'System disk-space usage is below 90%',
-				severity: 1,
-				businessImpact: 'New components will not be able to install and existing components will not refresh. As problem persists expect end user reports from critical sites regarding styling and broken functionality.',
-				technicalSummary: '/tmp directory is full, new components will not be installable.',
-				panicGuide: 'Restart the service dynos on Heroku'
 			}
 
 		],


### PR DESCRIPTION
It appears to return false incorrectly, which is causing downtime. This is a mitigation to get things working again over the bank holiday weekend until we can investigate further.