### PR TITLE
[EI-4701] -  Use regex to validate system codes instead of making HTTP calls to biz-ops-system-codes

### DIFF
--- a/lib/middleware/v3/parseSystemCodeParameter.js
+++ b/lib/middleware/v3/parseSystemCodeParameter.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const UserError = require('../../utils/usererror');
-const axios = require('axios').default;
 
 module.exports = {
 	parseSystemCodeParameter: parseSystemCodeParameter
@@ -33,7 +32,7 @@ async function parseSystemCodeParameter(systemCode) {
 		throw new UserError('The system_code query parameter can not be empty.');
 	}
 
-	if (await isValidSystemCode(systemCode)) {
+	if (isValidSystemCode(systemCode)) {
 		return systemCode;
 	} else {
 		throw new UserError('The system_code query parameter must be a valid Biz-Ops System Code.');
@@ -41,32 +40,13 @@ async function parseSystemCodeParameter(systemCode) {
 };
 
 /**
- * Confirm whether a system-code exists within Biz-Ops.
+ * Confirm whether a system-code matches the format of a Biz-Ops system code.
  *
- * @param {string} code The system-code to check exists in Biz-Ops.
- * @returns {Promise<boolean>} Returns true if the system-code exists in Biz-Ops and otherwise returns false.
+ * @param {string} code The system-code to check for validity.
+ * @returns {boolean} Returns true if the system-code is a valid Biz Ops system-code and otherwise returns false.
  */
-async function isValidSystemCode(code) {
-	try {
-		const response = await axios({
-			url: 'https://system-codes.in.ft.com/v1/check',
-			method: 'get', // default
-			params: {
-				systemCode: code
-			},
-			timeout: 1000 * 10,
-			responseType: 'json'
-		});
-
-		if (response.status === 200 && response.data.exists !== true) {
-			return false;
-		}
-
-		return true;
-	} catch (error) {
-		// If the request fails for any reason, we assume the code was a valid Biz-Ops system code.
-		// This ensures that if the https://system-codes.in.ft.com/ system is offline we can still
-		// serve responses to our users.
-		return true;
-	}
+function isValidSystemCode(code) {
+	// The pattern is taken from Biz-ops-schema which sets the valid system code pattern.
+	// https://github.com/Financial-Times/biz-ops-schema/blob/9babf227d2cd10bdae33821a2cd10b55c8e95856/schema/string-patterns.yaml#L3
+	return /^(?=.{2,64}$)[a-z0-9]+(?:-[a-z0-9]+)*$/.test(code);
 }


### PR DESCRIPTION
## Why
We had a discussion with the Origami team (@notlee) regarding the decommissioning of Biz Ops system codes and we have agreed that it is not essential to verify if a system code is valid or not by making HTTP call to [biz-ops-system-codes](https://system-codes.in.ft.com/) we can simply use a regex patter to check if it is a valid Biz ops system code. 

## What
- Replaces the HTTP call with a simple regex that checks whether a given system code follows a valid Biz ops system code format

### Anything in particular you'd like to highlight to reviewers?
The regex I have used is taken from [Biz ops schema](https://github.com/Financial-Times/biz-ops-schema/blob/9babf227d2cd10bdae33821a2cd10b55c8e95856/schema/string-patterns.yaml#L3) which Biz ops uses to validate system codes